### PR TITLE
Minor Fixes to Get Local Demo Working

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ Create a config.json file in your project.  Below is a sample configuration whic
         }
 
 Note: The proxyURL value should be defined as follows 'http://proxy.company.com:port'
+
+#Release Notes
+
+##1.0.0
+- MessagesClient now returns the original base64-encoded content on an attachment instead of uniformly converting to ascii.  This change allows retrieval of binary, base64 content, but impacts those clients who need ascii-encoded data.
+- SymConfigLoader now checks for either undefined, or empty values for client proxy configuration in config.json (`proxyURL`)
+- UsersClient now properly allows either uid-based, or email-based retrieval of user info in accordance with the users-lookup-v3 endoint as documented here: https://rest-api.symphony.com/reference#users-lookup-v3 

--- a/lib/MessagesClient/index.js
+++ b/lib/MessagesClient/index.js
@@ -57,7 +57,7 @@ MessagesClient.getAttachment = (streamId, attachmentId, messageId) => {
       if (SymBotAuth.debug) {
         console.log('[DEBUG]', 'MessagesClient/getAttachment/str', str)
       }
-      defer.resolve(Buffer.from(str, 'base64').toString('ascii'))
+      defer.resolve(Buffer.from(str, 'base64'))
     })
   })
 

--- a/lib/SymConfigLoader/index.js
+++ b/lib/SymConfigLoader/index.js
@@ -13,11 +13,11 @@ SymConfigLoader.loadFromFile = (path) => {
     } else {
       var config = JSON.parse(data)
       // proxy detection
-      if (config.proxyURL !== null && config.proxyURL !== '') {
+      if (config.proxyURL && config.proxyURL !== '') {
         let endpoint = config.proxyURL.substring(config.proxyURL.indexOf('://') + 3)
         let protocol = config.proxyURL.substring(0, config.proxyURL.indexOf('://'))
         let proxyURI = ''
-        if (config.proxyUsername !== null && config.proxyUsername !== '') {
+        if (config.proxyUsername && config.proxyUsername !== '') {
           proxyURI = protocol + config.proxyUsername + ':' + config.proxyPassword + '@' + endpoint
         } else {
           proxyURI = config.proxyURL

--- a/lib/UsersClient/index.js
+++ b/lib/UsersClient/index.js
@@ -149,11 +149,11 @@ UsersClient.getUsersFromIdList = (idList, local) => {
 
 UsersClient.getUsersV3 = (emailList, idList, local) => {
   var defer = Q.defer()
-
+  var listPart  = (emailList ? `email=${emailList}` : `uid=${idList}`);
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v3/users?emailList=' + emailList + '&idList=' + idList + '&local=' + (local ? 'true' : 'false'),
+    'path': `/pod/v3/users${listPart}&local=${(local ? 'true' : 'false')}`,
     'method': 'GET',
     'headers': {
       'sessionToken': SymBotAuth.sessionAuthToken

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-api-client-node",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "description": "Symphony API Client for NodeJS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I recently participated in a hackathon for my company, and needed the following changes in order to get our demonstration working.  Below is a summary of the changes for review.  Note, I am using node.js 8.10.0 in my local environment.

- Fixing null checks on config loader to properly detect undefined values in config.json, since the proxy value can be omitted rom the file (and was, in my case, having used the yeoman generator).
- Retaining base64 encoding on attachments in MessagesClient, so clients can decide whether to convert to ascii or not.  Particularly useful for images or other binary content like gzip archives as attachments.  

- Finally, changing the UsersClient to construct the proper URL query string according to the documentation here (https://rest-api.symphony.com/reference#users-lookup-v3), which requires either an email list or a uid list and never both.

Feel free to suggest an alternate implementation that better fits the overall design of the SDK.