### PR TITLE
Fix getUserIMStreamId

### DIFF
--- a/lib/StreamsClient/index.js
+++ b/lib/StreamsClient/index.js
@@ -9,10 +9,6 @@ var StreamsClient = {}
 StreamsClient.getUserIMStreamId = (userIDs) => {
   var defer = Q.defer()
 
-  var body = {
-    'userIDs': userIDs
-  }
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -37,7 +33,7 @@ StreamsClient.getUserIMStreamId = (userIDs) => {
       defer.resolve(JSON.parse(str))
     })
   })
-  req.write(JSON.stringify(body))
+  req.write(JSON.stringify(userIDs))
   req.end()
 
   return defer.promise


### PR DESCRIPTION
The default method fails no matter how you declare the userIDs. 

I have found that the example available at the official documentation only writes the serialized list, instead of a JSON object. Doing the same thing here fixes this problem.

https://github.com/SymphonyPlatformSolutions/symphony-api-client-node/issues/35