### PR TITLE
Expose MessagesClient.getMessage via SymBotClient

### DIFF
--- a/lib/SymBotClient/index.js
+++ b/lib/SymBotClient/index.js
@@ -276,6 +276,16 @@ SymBotClient.getAttachment = (streamId, attachmentId, messageId) => {
   return defer.promise
 }
 
+SymBotClient.getMessage = (messageId) => {
+  var defer = Q.defer()
+
+  MessagesClient.getMessage(messageId).then((res) => {
+    defer.resolve(res)
+  })
+
+  return defer.promise
+}
+
 /* On Behalf Of - OBOClient Services */
 SymBotClient.oboAuthenticateByUserId = (userId) => {
   var defer = Q.defer()


### PR DESCRIPTION
I missed adding the wrapper function for `MessagesClient.getMessage` in `SymBotClient` during my original PR for adding getMessage support.