### PR TITLE
Fix support for PKCS12 certificate files

### DIFF
--- a/lib/SymBotAuth/index.js
+++ b/lib/SymBotAuth/index.js
@@ -34,13 +34,12 @@ SymBotAuth.sessionAuthenticate = (symConfig) => {
       'port': symConfig.sessionAuthPort,
       'path': '/sessionauth/v1/authenticate',
       'method': 'POST',
-      'key': fs.readFileSync(symConfig.botCertPath + symConfig.botCertName, 'utf8'),
-      'cert': fs.readFileSync(symConfig.botCertPath + symConfig.botCertName, 'utf8'),
+      'pfx': fs.readFileSync(symConfig.botCertPath + symConfig.botCertName),
       'passphrase': symConfig.botCertPassword,
       'agent': symConfig.proxy
     }
   }
-  console.log('options', options)
+
   var req = https.request(options, function (res) {
     var str = ''
     res.on('data', function (chunk) {
@@ -94,12 +93,11 @@ SymBotAuth.kmAuthenticate = (symConfig) => {
       'port': symConfig.keyAuthPort,
       'path': '/keyauth/v1/authenticate',
       'method': 'POST',
-      'key': fs.readFileSync(symConfig.botCertPath + symConfig.botCertName, 'utf8'),
-      'cert': fs.readFileSync(symConfig.botCertPath + symConfig.botCertName, 'utf8'),
+      'pfx': fs.readFileSync(symConfig.botCertPath + symConfig.botCertName),
       'passphrase': symConfig.botCertPassword,
       'agent': symConfig.proxy
     }
-  };
+  }
 
   var req = https.request(options, function (res) {
     var str = ''
@@ -152,13 +150,12 @@ SymBotAuth.applicationAuthenticate = (symConfig) => {
       'port': symConfig.sessionAuthPort,
       'path': '/sessionauth/v1/app/authenticate',
       'method': 'POST',
-      'key': fs.readFileSync(symConfig.appCertPath + symConfig.appCertName, 'utf8'),
-      'cert': fs.readFileSync(symConfig.appCertPath + symConfig.appCertName, 'utf8'),
+      'pfx': fs.readFileSync(symConfig.appCertPath + symConfig.appCertName),
       'passphrase': symConfig.appCertPassword,
       'agent': symConfig.proxy
     }
   }
-  console.log('options', options)
+
   var req = https.request(options, function (res) {
     var str = ''
     res.on('data', function (chunk) {
@@ -220,7 +217,7 @@ SymBotAuth.oboAuthenticateByUserId = (userId) => {
       'agent': SymBotAuth.symConfig.proxy
     }
   }
-  console.log('options', options)
+
   var req = https.request(options, function (res) {
     var str = ''
     res.on('data', function (chunk) {
@@ -276,13 +273,12 @@ SymBotAuth.oboAuthenticateByUsername = (symConfig, username) => {
       'port': symConfig.sessionAuthPort,
       'path': '/sessionauth/v1/app/username/' + username + '/authenticate',
       'method': 'POST',
-      'key': fs.readFileSync(symConfig.appCertPath + symConfig.appCertName, 'utf8'),
-      'cert': fs.readFileSync(symConfig.appCertPath + symConfig.appCertName, 'utf8'),
+      'pfx': fs.readFileSync(symConfig.appCertPath + symConfig.appCertName),
       'passphrase': symConfig.appCertPassword,
       'agent': symConfig.proxy
     }
   }
-  console.log('options', options)
+
   var req = https.request(options, function (res) {
     var str = ''
     res.on('data', function (chunk) {

--- a/tests/SymBotAuth/__snapshots__/index.test.js.snap
+++ b/tests/SymBotAuth/__snapshots__/index.test.js.snap
@@ -5,12 +5,11 @@ Array [
   Array [
     Object {
       "agent": "agent",
-      "cert": "Contents of /I am the cert",
       "hostname": "https://key.example.com",
-      "key": "Contents of /I am the key",
       "method": "POST",
       "passphrase": "Passphrase",
       "path": "/keyauth/v1/authenticate",
+      "pfx": "Contents of /I am the cert",
       "port": 5678,
     },
     [Function],
@@ -23,12 +22,11 @@ Array [
   Array [
     Object {
       "agent": "agent",
-      "cert": "Contents of /I am the cert",
       "hostname": "https://session.example.com",
-      "key": "Contents of /I am the key",
       "method": "POST",
       "passphrase": "Passphrase",
       "path": "/sessionauth/v1/authenticate",
+      "pfx": "Contents of /I am the cert",
       "port": 1234,
     },
     [Function],

--- a/tests/SymBotAuth/index.test.js
+++ b/tests/SymBotAuth/index.test.js
@@ -29,7 +29,6 @@ describe('SymBotAuth', () => {
         SymBotAuth.sessionAuthenticate({
           botCertPath: "/",
           botCertName: "I am the cert",
-          botKeyName: "I am the key",
           sessionAuthHost: "https://session.example.com",
           sessionAuthPort: 1234,
           botCertPassword: "Passphrase",
@@ -47,7 +46,6 @@ describe('SymBotAuth', () => {
         SymBotAuth.kmAuthenticate({
           botCertPath: "/",
           botCertName: "I am the cert",
-          botKeyName: "I am the key",
           keyAuthHost: "https://key.example.com",
           keyAuthPort: 5678,
           botCertPassword: "Passphrase",


### PR DESCRIPTION
According to the [Node docs](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) the `key` and `cert` options to `https.request` expect a private and public key in PEM format. If `botCertName` is a PKCS12 file it should be provided to `https.request` in the `pfx` option.

Also removed some console logging.