### PR TITLE
Factor out common pod/agent connection parameters

### DIFF
--- a/lib/AdminClient/index.js
+++ b/lib/AdminClient/index.js
@@ -1,91 +1,61 @@
-const SymConfigLoader = require('../SymConfigLoader')
-const SymBotAuth = require('../SymBotAuth')
-const request = require('../Request')
+const { podRequest, agentRequest } = require('../Request/clients')
 
-var AdminClient = {}
+const AdminClient = {}
 
 // List Enterprise streams for calling users company using https://rest-api.symphony.com/docs/list-streams-for-enterprise-v2
-AdminClient.adminListEnterpriseStreamsV2 = (streamTypes, scope, origin, privacy, status, startDate, endDate, skip = 0, limit = 100) => {
-  var body = {
-    'streamTypes': streamTypes,
-    'scope': scope,
-    'origin': origin,
-    'privacy': privacy,
-    'status': status,
-    'startDate': startDate,
-    'endDate': endDate
+AdminClient.adminListEnterpriseStreamsV2 = (
+  streamTypes,
+  scope,
+  origin,
+  privacy,
+  status,
+  startDate,
+  endDate,
+  skip = 0,
+  limit = 100
+) => {
+  const body = {
+    streamTypes: streamTypes,
+    scope: scope,
+    origin: origin,
+    privacy: privacy,
+    status: status,
+    startDate: startDate,
+    endDate: endDate,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v2/admin/streams/list?skip=' + skip + '&limit=' + limit,
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'AdminClient/adminListEnterpriseStreamsV2', body)
+  return podRequest(
+    'post',
+    `/pod/v2/admin/streams/list?skip=${skip}&limit=${limit}`,
+    'AdminClient/adminListEnterpriseStreamsV2',
+    body
+  )
 }
 
 // List all current members of a stream using https://rest-api.symphony.com/docs/stream-members
-AdminClient.streamMembers = (id, skip = 0, limit = 1000) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/admin/stream/' + id + '/membership/list?skip=' + skip + '&limit=' + limit,
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'AdminClient/streamMembers')
-}
+AdminClient.streamMembers = (id, skip = 0, limit = 1000) =>
+  podRequest(
+    'get',
+    `/pod/v1/admin/stream/${id}/membership/list?skip=${skip}&limit=${limit}`,
+    'AdminClient/streamMembers'
+  )
 
 // Import messages to Symphony using https://rest-api.symphony.com/docs/import-message-v4
 // Note: Formatting for messages https://rest-api.symphony.com/v1.52/docs/import-message-v4#v4importedmessage-format
-AdminClient.importMessages = (messageList) => {
-  var body = {
-    'messageList': messageList
+AdminClient.importMessages = messageList => {
+  const body = {
+    messageList: messageList,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v4/message/import',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'AdminClient/importMessages', body)
+  return agentRequest('post', '/agent/v4/message/import', 'AdminClient/importMessages', body)
 }
 
 // Suppress a message from a stream using https://rest-api.symphony.com/docs/suppress-message
-AdminClient.suppressMessage = (id) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/admin/messagesuppression/' + id + '/suppress',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'AdminClient/suppressMessage')
-}
+AdminClient.suppressMessage = id =>
+  podRequest(
+    'post',
+    `/pod/v1/admin/messagesuppression/${id}/suppress`,
+    'AdminClient/suppressMessage'
+  )
 
 module.exports = AdminClient

--- a/lib/AdminUserClient/index.js
+++ b/lib/AdminUserClient/index.js
@@ -1,41 +1,17 @@
-const SymConfigLoader = require('../SymConfigLoader')
-const SymBotAuth = require('../SymBotAuth')
-const request = require('../Request')
+const { podRequest } = require('../Request/clients')
 
-var AdminUserClient = {}
+const AdminUserClient = {}
 
 // Get User V2 using https://rest-api.symphony.com/reference#get-user-v2
-AdminUserClient.getUser = (id) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v2/admin/user/' + id,
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'AdminUserClient/getUser')
-}
+AdminUserClient.getUser = id =>
+  podRequest('get', `/pod/v2/admin/user/${id}`, 'AdminUserClient/getUser')
 
 // List all users using https://rest-api.symphony.com/reference#list-users-v2
-AdminUserClient.listUsers = (skip = 0, limit = 1000) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v2/admin/user/list?skip=' + skip + '&limit=' + limit,
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'AdminUserClient/listUsers')
-}
+AdminUserClient.listUsers = (skip = 0, limit = 1000) =>
+  podRequest(
+    'get',
+    `/pod/v2/admin/user/list?skip=${skip}&limit=${limit}`,
+    'AdminUserClient/listUsers'
+  )
 
 module.exports = AdminUserClient

--- a/lib/ConnectionsClient/index.js
+++ b/lib/ConnectionsClient/index.js
@@ -1,8 +1,6 @@
-const SymConfigLoader = require('../SymConfigLoader')
-const SymBotAuth = require('../SymBotAuth')
-const request = require('../Request')
+const { podRequest } = require('../Request/clients')
 
-var ConnectionsClient = {}
+const ConnectionsClient = {}
 
 ConnectionsClient.PENDING_INCOMING = 'Pending Incoming'
 ConnectionsClient.PENDING_OUTGOING = 'Pending Outgoing'
@@ -11,202 +9,105 @@ ConnectionsClient.REJECTED = 'Rejected'
 ConnectionsClient.ALL = 'All'
 
 // List pending outbound connection requests using https://rest-api.symphony.com/docs/list-connections
-ConnectionsClient.getPendingConnections = (status) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/list?status=pending_outgoing',
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/getPendingConnections')
-}
+ConnectionsClient.getPendingConnections = () =>
+  podRequest(
+    'GET',
+    '/pod/v1/connnection/list?status=pending_outgoing',
+    'ConnectionsClient/getPendingConnections'
+  )
 
 // List pending inbound connection requests using https://rest-api.symphony.com/docs/list-connections
-ConnectionsClient.getInboundPendingConnections = (status) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/list?status=pending_incoming',
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/getInboundPendingConnections')
-}
+ConnectionsClient.getInboundPendingConnections = () =>
+  podRequest(
+    'GET',
+    '/pod/v1/connnection/list?status=pending_incoming',
+    'ConnectionsClient/getInboundPendingConnections'
+  )
 
 // List all current connections using https://rest-api.symphony.com/docs/list-connections
-ConnectionsClient.getAllConnections = (status) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/list?status=all',
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/getAllConnections')
-}
+ConnectionsClient.getAllConnections = () =>
+  podRequest('GET', '/pod/v1/connnection/list?status=all', 'ConnectionsClient/getAllConnections')
 
 // List accepted connections using https://rest-api.symphony.com/docs/list-connections
-ConnectionsClient.getAcceptedConnections = (status) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/list?status=accepted',
-    'method': 'GET',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/getAcceptedConnections')
-}
+ConnectionsClient.getAcceptedConnections = () =>
+  podRequest(
+    'GET',
+    '/pod/v1/connnection/list?status=accepted',
+    'ConnectionsClient/getAcceptedConnections'
+  )
 
 // List rejected connections using https://rest-api.symphony.com/docs/list-connections
-ConnectionsClient.getRejectedConnections = (status) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/list?status=rejected',
-    'method': 'GET',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/getRejectedConnections')
-}
+ConnectionsClient.getRejectedConnections = () =>
+  podRequest(
+    'GET',
+    '/pod/v1/connnection/list?status=rejected',
+    'ConnectionsClient/getRejectedConnections'
+  )
 
 // List connection status for an array of users https://rest-api.symphony.com/docs/list-connections
-ConnectionsClient.getConnections = (status, userIds) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/list?status=all?userIds=' + userIds,
-    'method': 'GET',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/getConnections')
-}
+ConnectionsClient.getConnections = (status, userIds) =>
+  podRequest(
+    'GET',
+    `/pod/v1/connnection/list?status=all?userIds=${userIds}`,
+    'ConnectionsClient/getConnections'
+  )
 
 // Accept connection request from a requesting user https://rest-api.symphony.com/docs/accepted-connection
-ConnectionsClient.acceptConnectionRequest = (userId) => {
-  var body = {
-    'userId': userId
+ConnectionsClient.acceptConnectionRequest = userId => {
+  const body = {
+    userId: userId,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/accept',
-    'method': 'POST',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/acceptConnectionRequest', body)
+  return podRequest(
+    'POST',
+    '/pod/v1/connnection/accept',
+    'ConnectionsClient/acceptConnectionRequest',
+    body
+  )
 }
 
 // Reject connection request from a requesting user https://rest-api.symphony.com/docs/reject-connection
-ConnectionsClient.rejectConnectionRequest = (userId) => {
-  var body = {
-    'userId': userId
+ConnectionsClient.rejectConnectionRequest = userId => {
+  const body = {
+    userId: userId,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/reject',
-    'method': 'POST',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/rejectConnectionRequest', body)
+  return podRequest(
+    'POST',
+    '/pod/v1/connnection/reject',
+    'ConnectionsClient/rejectConnectionRequest',
+    body
+  )
 }
 
 // Create a connection request to another user https://rest-api.symphony.com/docs/create-connection
-ConnectionsClient.sendConnectionRequest = (userId) => {
-  var body = {
-    'userId': userId
+ConnectionsClient.sendConnectionRequest = userId => {
+  const body = {
+    userId: userId,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/create',
-    'method': 'POST',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/sendConnectionRequest', body)
+  return podRequest(
+    'POST',
+    '/pod/v1/connnection/create',
+    'ConnectionsClient/sendConnectionRequest',
+    body
+  )
 }
 
 // Remove an existing connection to another user https://rest-api.symphony.com/docs/remove-connection
-ConnectionsClient.removeConnection = (userId) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/user/' + userId + '/remove',
-    'method': 'POST',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/removeConnection')
-}
+ConnectionsClient.removeConnection = userId =>
+  podRequest(
+    'POST',
+    `/pod/v1/connnection/user/${userId}/remove`,
+    'ConnectionsClient/removeConnection'
+  )
 
 // Get connection status for another user https://rest-api.symphony.com/docs/get-connection
-ConnectionsClient.getConnectionRequestStatus = (userId) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/user/' + userId + '/info',
-    'method': 'GET',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'ConnectionsClient/getConnectionRequestStatus')
-}
+ConnectionsClient.getConnectionRequestStatus = userId =>
+  podRequest(
+    'GET',
+    `/pod/v1/connnection/user/${userId}/info`,
+    'ConnectionsClient/getConnectionRequestStatus'
+  )
 
 module.exports = ConnectionsClient

--- a/lib/PresenceClient/index.js
+++ b/lib/PresenceClient/index.js
@@ -1,8 +1,6 @@
-const SymConfigLoader = require('../SymConfigLoader')
-const SymBotAuth = require('../SymBotAuth')
-const request = require('../Request')
+const { podRequest } = require('../Request/clients')
 
-var PresenceClient = {}
+const PresenceClient = {}
 
 PresenceClient.STATUS_AVAILABLE = 'AVAILABLE'
 PresenceClient.STATUS_BUSY = 'BUSY'
@@ -13,53 +11,22 @@ PresenceClient.STATUS_IN_A_MEETING = 'IN_A_MEETING'
 PresenceClient.STATUS_OUT_OF_OFFICE = 'OUT_OF_OFFICE'
 PresenceClient.STATUS_OFF_WORK = 'OFF_WORK'
 
-PresenceClient.getUserPresence = (userId, local) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v3/user/' + userId + '/presence?local=' + (local ? 'true' : 'false'),
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
+PresenceClient.getUserPresence = (userId, local) =>
+  podRequest(
+    'GET',
+    `/pod/v3/user/${userId}/presence?local=${local ? 'true' : 'false'}`,
+    'UsersClient/getUserPresence'
+  )
+
+PresenceClient.setPresence = status => {
+  const body = {
+    category: status,
   }
 
-    return request(options, 'UsersClient/getUserPresence')
+  return podRequest('POST', '/pod/v2/user/presence', 'UsersClient/setPresence', body)
 }
 
-PresenceClient.setPresence = (status) => {
-  var body = {
-    'category': status
-  }
-
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v2/user/presence',
-    'method': 'POST',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-    return request(options, 'UsersClient/setPresence', body)
-}
-
-PresenceClient.registerInterestExtUser = (idList) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/user/presence/register',
-    'method': 'POST',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-    return request(options, 'UsersClient/registerInterestExtUser')
-}
+PresenceClient.registerInterestExtUser = () =>
+  podRequest('POST', '/pod/v1/user/presence/register', 'UsersClient/registerInterestExtUser')
 
 module.exports = PresenceClient

--- a/lib/Request/clients.js
+++ b/lib/Request/clients.js
@@ -1,0 +1,40 @@
+const SymBotAuth = require('../SymBotAuth')
+const SymConfigLoader = require('../SymConfigLoader')
+const request = require('.')
+
+function podRequest(method, path, debugId, body) {
+  return request(
+    {
+      method,
+      path,
+      hostname: SymConfigLoader.SymConfig.podHost,
+      port: SymConfigLoader.SymConfig.podPort,
+      agent: SymConfigLoader.SymConfig.podProxy,
+      headers: {
+        sessionToken: SymBotAuth.sessionAuthToken,
+      },
+    },
+    debugId,
+    body
+  )
+}
+
+function agentRequest(method, path, debugId, body) {
+  return request(
+    {
+      method,
+      path,
+      hostname: SymConfigLoader.SymConfig.agentHost,
+      port: SymConfigLoader.SymConfig.agentPort,
+      agent: SymConfigLoader.SymConfig.agentProxy,
+      headers: {
+        sessionToken: SymBotAuth.sessionAuthToken,
+        keyManagerToken: SymBotAuth.kmAuthToken,
+      },
+    },
+    debugId,
+    body
+  )
+}
+
+module.exports = { podRequest, agentRequest }

--- a/lib/Request/index.js
+++ b/lib/Request/index.js
@@ -9,7 +9,11 @@ module.exports = function request(options, debugId, body) {
     if (SymBotAuth.debug) {
       console.log('[ERROR]', debugId + '/err', err)
     }
-    defer.reject({ 'status': 'error' })
+    defer.reject({ status: 'error' })
+  }
+
+  if (body && !options.headers['Content-Type']) {
+    options.headers['Content-Type'] = 'application/json'
   }
 
   const req = https.request(options, res => {
@@ -21,7 +25,7 @@ module.exports = function request(options, debugId, body) {
       if (SymBotAuth.debug) {
         console.log('[DEBUG]', debugId + '/str', str)
       }
-      defer.resolve((str === '') ? {} : JSON.parse(str))
+      defer.resolve(str === '' ? {} : JSON.parse(str))
     })
     res.on('error', errorHandler)
   })

--- a/lib/SignalsClient/index.js
+++ b/lib/SignalsClient/index.js
@@ -1,174 +1,82 @@
-const SymConfigLoader = require('../SymConfigLoader')
-const SymBotAuth = require('../SymBotAuth')
-const request = require('../Request')
+const { agentRequest } = require('../Request/clients')
 
-var SignalsClient = {}
+const SignalsClient = {}
 
 // List signals on behalf of the service user using https://rest-api.symphony.com/docs/list-signals
-SignalsClient.listSignals = (skip = 0, limit = 50) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v1/signals/list?skip=' + skip + '&limit=' + limit,
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'SignalsClient/listSignals')
-}
+SignalsClient.listSignals = (skip = 0, limit = 50) =>
+  agentRequest(
+    'GET',
+    `/agent/v1/signals/list?skip=${skip}&limit=${limit}`,
+    'SignalsClient/listSignals'
+  )
 
 // Get information about a signal using https://rest-api.symphony.com/docs/get-signal
-SignalsClient.getSignal = (id) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v1/signals/' + id + '/get',
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'SignalsClient/getSignal')
-}
+SignalsClient.getSignal = id =>
+  agentRequest('GET', `/agent/v1/signals/${id}/get`, 'SignalsClient/getSignal')
 
 // Create a new signal using https://rest-api.symphony.com/docs/create-signal
 SignalsClient.createSignal = (name, query, visibleOnProfile = true, companyWide = false) => {
-  var body = {
-    'name': name,
-    'query': query,
-    'visibleOnProfile': visibleOnProfile,
-    'companyWide': companyWide
+  const body = {
+    name: name,
+    query: query,
+    visibleOnProfile: visibleOnProfile,
+    companyWide: companyWide,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v1/signals/create',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'SignalsClient/createSignal', body)
+  return agentRequest('POST', '/agent/v1/signals/create', 'SignalsClient/createSignal', body)
 }
 
 // Update an existing signal using https://rest-api.symphony.com/docs/update-signal
 SignalsClient.updateSignal = (id, name, query, visibleOnProfile, companyWide) => {
-  var body = {
-    'name': name,
-    'query': query,
-    'visibleOnProfile': visibleOnProfile,
-    'companyWide': companyWide
+  const body = {
+    name: name,
+    query: query,
+    visibleOnProfile: visibleOnProfile,
+    companyWide: companyWide,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v1/signals/' + id + '/update',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'SignalsClient/updateSignal', body)
+  return agentRequest('POST', `/agent/v1/signals/${id}/update`, 'SignalsClient/updateSignal', body)
 }
 
 // Delete an existing signal using https://rest-api.symphony.com/docs/delete-signal
-SignalsClient.deleteSignal = (id) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v1/signals/' + id + '/delete',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'SignalsClient/deleteSignal')
-}
+SignalsClient.deleteSignal = id =>
+  agentRequest('POST', `/agent/v1/signals/${id}/delete`, 'SignalsClient/deleteSignal')
 
 // Subscribe user(s) to an existing signal using https://rest-api.symphony.com/docs/subscribe-signal
 // Note: To subscribe an entire pod to a Signal, set the companyWide field to true using SignalsClient.updateSignal
 SignalsClient.subscribeSignal = (id, userIds, userCanUnsubscribe) => {
-  var body = {
-    'users': userIds
+  const body = {
+    users: userIds,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v1/signals/' + id + '/subscribe?pushed=' + (userCanUnsubscribe ? 'true' : 'false'),
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'SignalsClient/subscribeSignal', body)
+  return agentRequest(
+    'POST',
+    `/agent/v1/signals/${id}/subscribe?pushed=${userCanUnsubscribe ? 'true' : 'false'}`,
+    'SignalsClient/subscribeSignal',
+    body
+  )
 }
 
 // Unsubscribe user(s) to an existing signal using https://rest-api.symphony.com/docs/unsubscribe-signal
 SignalsClient.unsubscribeSignal = (id, userIds) => {
-  var body = {
-    'users': userIds
+  const body = {
+    users: userIds,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v1/signals/' + id + '/unsubscribe',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'SignalsClient/unsubscribeSignal', body)
+  return agentRequest(
+    'POST',
+    `/agent/v1/signals/${id}/unsubscribe`,
+    'SignalsClient/unsubscribeSignal',
+    body
+  )
 }
 
 // List users subscribed to an existing signal using https://rest-api.symphony.com/docs/subscribers
-SignalsClient.getSignalSubscribers = (id, skip = 0, limit = 50) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/agent/v1/signals/' + id + '/subscribers?skip=' + skip + '&limit=' + limit,
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.keyManagerToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'SignalsClient/getSignalSubscribers')
-}
+SignalsClient.getSignalSubscribers = (id, skip = 0, limit = 50) =>
+  agentRequest(
+    'GET',
+    `/agent/v1/signals/${id}/subscribers?skip=${skip}&limit=${limit}`,
+    'SignalsClient/getSignalSubscribers'
+  )
 
 module.exports = SignalsClient

--- a/lib/StreamsClient/index.js
+++ b/lib/StreamsClient/index.js
@@ -1,282 +1,191 @@
-const SymConfigLoader = require('../SymConfigLoader')
-const SymBotAuth = require('../SymBotAuth')
-const request = require('../Request')
+const { podRequest } = require('../Request/clients')
 
-var StreamsClient = {}
+const StreamsClient = {}
 
 // Get StreamID for user(s) using https://rest-api.symphony.com/docs/create-im-or-mim
-StreamsClient.getUserIMStreamId = (userIDs) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/im/create',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/getUserIMStreamId', userIDs)
-}
+StreamsClient.getUserIMStreamId = userIDs =>
+  podRequest('POST', '/pod/v1/im/create', 'StreamsClient/getUserIMStreamId', userIDs)
 
 // Create room using https://rest-api.symphony.com/docs/create-room-v3
-StreamsClient.createRoom = (room, description, keywords, membersCanInvite = true, discoverable = true, anyoneCanJoin = false, readOnly = false, copyProtected = false, crossPod = false, viewHistory = false) => {
-  var body = {
-    'name': room,
-    'description': description,
-    'keywords': keywords,
-    'membersCanInvite': membersCanInvite,
-    'discoverable': discoverable,
-    'public': anyoneCanJoin,
-    'readOnly': readOnly,
-    'copyProtected': copyProtected,
-    'crossPod': crossPod,
-    'viewHistory': viewHistory
+StreamsClient.createRoom = (
+  room,
+  description,
+  keywords,
+  membersCanInvite = true,
+  discoverable = true,
+  anyoneCanJoin = false,
+  readOnly = false,
+  copyProtected = false,
+  crossPod = false,
+  viewHistory = false
+) => {
+  const body = {
+    name: room,
+    description: description,
+    keywords: keywords,
+    membersCanInvite: membersCanInvite,
+    discoverable: discoverable,
+    public: anyoneCanJoin,
+    readOnly: readOnly,
+    copyProtected: copyProtected,
+    crossPod: crossPod,
+    viewHistory: viewHistory,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v3/room/create',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/createRoom', body)
+  return podRequest('POST', '/pod/v3/room/create', 'StreamsClient/createRoom', body)
 }
 
 // Update room using https://rest-api.symphony.com/docs/update-room-v3
-StreamsClient.updateRoom = (streamId, room, description, keywords, membersCanInvite, discoverable, anyoneCanJoin, readOnly, copyProtected, crossPod, viewHistory) => {
-  var body = {
-    'name': room,
-    'description': description,
-    'keywords': keywords,
-    'membersCanInvite': membersCanInvite,
-    'discoverable': discoverable,
-    'public': anyoneCanJoin,
-    'readOnly': readOnly,
-    'copyProtected': copyProtected,
-    'crossPod': crossPod,
-    'viewHistory': viewHistory
+StreamsClient.updateRoom = (
+  streamId,
+  room,
+  description,
+  keywords,
+  membersCanInvite,
+  discoverable,
+  anyoneCanJoin,
+  readOnly,
+  copyProtected,
+  crossPod,
+  viewHistory
+) => {
+  const body = {
+    name: room,
+    description: description,
+    keywords: keywords,
+    membersCanInvite: membersCanInvite,
+    discoverable: discoverable,
+    public: anyoneCanJoin,
+    readOnly: readOnly,
+    copyProtected: copyProtected,
+    crossPod: crossPod,
+    viewHistory: viewHistory,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v3/room/' + streamId + '/update',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/updateRoom', body)
+  return podRequest('POST', `/pod/v3/room/${streamId}/update`, 'StreamsClient/updateRoom', body)
 }
 
 // Room Information using https://rest-api.symphony.com/docs/room-info-v3
-StreamsClient.getRoomInfo = (streamId) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v3/room/' + streamId + '/info',
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/getRoomInfo')
-}
+StreamsClient.getRoomInfo = streamId =>
+  podRequest('GET', `/pod/v3/room/${streamId}/info`, 'StreamsClient/getRoomInfo')
 
 // Re-Activate Room using https://rest-api.symphony.com/docs/de-or-re-activate-room
-StreamsClient.activateRoom = (streamId) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/room/' + streamId + '/setActive?active=true',
-    'method': 'POST',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/activateRoom')
-}
+StreamsClient.activateRoom = streamId =>
+  podRequest('POST', `/pod/v1/room/${streamId}/setActive?active=true`, 'StreamsClient/activateRoom')
 
 // De-Activate Room using https://rest-api.symphony.com/docs/de-or-re-activate-room
-StreamsClient.deactivateRoom = (streamId) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/room/' + streamId + '/setActive?active=false',
-    'method': 'POST',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/deactivateRoom')
-}
+StreamsClient.deactivateRoom = streamId =>
+  podRequest(
+    'POST',
+    `/pod/v1/room/${streamId}/setActive?active=false`,
+    'StreamsClient/deactivateRoom'
+  )
 
 // Room Members using https://rest-api.symphony.com/docs/room-members
-StreamsClient.getRoomMembers = (streamId) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v2/room/' + streamId + '/membership/list',
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/getRoomMembers')
-}
+StreamsClient.getRoomMembers = streamId =>
+  podRequest('GET', `/pod/v2/room/${streamId}/membership/list`, 'StreamsClient/getRoomMembers')
 
 // Add Member to existing room using https://rest-api.symphony.com/docs/add-member
 StreamsClient.addMemberToRoom = (streamId, userId) => {
-  var body = {
-    'id': userId
+  const body = {
+    id: userId,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/room/' + streamId + '/membership/add',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/addMemberToRoom', body)
+  return podRequest(
+    'POST',
+    `/pod/v1/room/${streamId}/membership/add`,
+    'StreamsClient/addMemberToRoom',
+    body
+  )
 }
 
 // Remove Member to existing room using https://rest-api.symphony.com/docs/remove-member
 StreamsClient.removeMemberFromRoom = (streamId, userId) => {
-  var body = {
-    'id': userId
+  const body = {
+    id: userId,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/room/' + streamId + '/membership/remove',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/removeMemberFromRoom', body)
+  return podRequest(
+    'POST',
+    `/pod/v1/room/${streamId}/membership/remove`,
+    'StreamsClient/removeMemberFromRoom',
+    body
+  )
 }
 
 // Promote Member to owner of room using https://rest-api.symphony.com/docs/promote-owner
 StreamsClient.promoteUserToOwner = (streamId, userId) => {
-  var body = {
-    'id': userId
+  const body = {
+    id: userId,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/room/' + streamId + '/membership/promoteOwner',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/promoteUserToOwner', body)
+  return podRequest(
+    'POST',
+    `/pod/v1/room/${streamId}/membership/promoteOwner`,
+    'StreamsClient/promoteUserToOwner',
+    body
+  )
 }
 
 // Demote Member from owner of room using https://rest-api.symphony.com/docs/promote-owner
 StreamsClient.demoteUserFromOwner = (streamId, userId) => {
-  var body = {
-    'id': userId
+  const body = {
+    id: userId,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/room/' + streamId + '/membership/demoteOwner',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/demoteUserFromOwner', body)
+  return podRequest(
+    'POST',
+    `/pod/v1/room/${streamId}/membership/demoteOwner`,
+    'StreamsClient/demoteUserFromOwner',
+    body
+  )
 }
 
 // Search Rooms using https://rest-api.symphony.com/docs/search-rooms-v3
-StreamsClient.searchRooms = (skip = 0, limit = 100, query, labels, active = true, includePrivateRooms = false, creator, owner, member, sortOrder = 'RELEVANCE') => {
-  var body = {
-    'query': query,
-    'labels': labels,
-    'active': active,
-    'private': includePrivateRooms,
-    'creator': creator,
-    'owner': owner,
-    'member': member,
-    'sortOrder': sortOrder
+StreamsClient.searchRooms = (
+  skip = 0,
+  limit = 100,
+  query,
+  labels,
+  active = true,
+  includePrivateRooms = false,
+  creator,
+  owner,
+  member,
+  sortOrder = 'RELEVANCE'
+) => {
+  const body = {
+    query: query,
+    labels: labels,
+    active: active,
+    private: includePrivateRooms,
+    creator: creator,
+    owner: owner,
+    member: member,
+    sortOrder: sortOrder,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v3/room/search?skip=' + skip + '&limit=' + limit,
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/searchRooms', body)
+  return podRequest(
+    'POST',
+    `/pod/v3/room/search?skip=${skip}&limit=${limit}`,
+    'StreamsClient/searchRooms',
+    body
+  )
 }
 
 // List User Streams using https://rest-api.symphony.com/docs/list-user-streams
 StreamsClient.getUserStreams = (skip = 0, limit = 100, streamTypes, includeInactiveStreams) => {
-  var body = {
-    'streamTypes': streamTypes,
-    'includeInactiveStreams': includeInactiveStreams
+  const body = {
+    streamTypes: streamTypes,
+    includeInactiveStreams: includeInactiveStreams,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/streams/list?skip=' + skip + '&limit=' + limit,
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'StreamsClient/getUserStreams', body)
+  return podRequest(
+    'POST',
+    `/pod/v1/streams/list?skip=${skip}&limit=${limit}`,
+    'StreamsClient/getUserStreams',
+    body
+  )
 }
 
 module.exports = StreamsClient

--- a/lib/UsersClient/index.js
+++ b/lib/UsersClient/index.js
@@ -1,119 +1,52 @@
-const SymConfigLoader = require('../SymConfigLoader')
-const SymBotAuth = require('../SymBotAuth')
-const request = require('../Request')
+const { podRequest } = require('../Request/clients')
 
-var UsersClient = {}
+const UsersClient = {}
 
 // Look up user with a username via https://rest-api.symphony.com/reference#user-lookup
-UsersClient.getUserFromUsername = (username) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v2/user?username=' + username,
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'UsersClient/getUserFromUsername')
-}
+UsersClient.getUserFromUsername = username =>
+  podRequest('get', `/pod/v2/user?username=${username}`, 'UsersClient/getUserFromUsername')
 
 // Look up user with an email via https://rest-api.symphony.com/reference#user-lookup
-UsersClient.getUserFromEmail = (email, local) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v2/user?email=' + email + '&local=' + (local ? 'true' : 'false'),
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
+UsersClient.getUserFromEmail = (email, local) =>
+  podRequest(
+    'get',
+    `/pod/v2/user?email=${email}&local=${local ? 'true' : 'false'}`,
+    'UsersClient/getUserFromEmail'
+  )
 
-  return request(options, 'UsersClient/getUserFromEmail')
-}
+// Look up user with one or more comma separated emails via https://rest-api.symphony.com/reference#users-lookup-v3
+UsersClient.getUserFromEmailV3 = (email, local) =>
+  podRequest(
+    'get',
+    `/pod/v3/users?email=${email}&local=${local ? 'true' : 'false'}`,
+    'UsersClient/getUserFromEmailV3'
+  )
 
-// Look up user with an email via https://rest-api.symphony.com/reference#users-lookup-v3
-UsersClient.getUserFromEmailV3 = (email, local) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v3/users?email=' + email + '&local=' + (local ? 'true' : 'false'),
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
+// Look up user with one or more comma separated via https://rest-api.symphony.com/reference#users-lookup-v3
+UsersClient.getUserFromIdV3 = (id, local) =>
+  podRequest(
+    'get',
+    `/pod/v3/users?uid=${id}&local=${local ? 'true' : 'false'}`,
+    'UsersClient/getUserFromIdV3'
+  )
 
-  return request(options, 'UsersClient/getUserFromEmailV3')
-}
-
-// Look up user with a userID via https://rest-api.symphony.com/reference#users-lookup-v3
-UsersClient.getUserFromIdV3 = (id, local) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v3/users?uid=' + id + '&local=' + (local ? 'true' : 'false'),
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'UsersClient/getUserFromIdV3')
-}
-
-// Look up multiple users with an email via https://rest-api.symphony.com/reference#users-lookup-v3
-UsersClient.getUsersFromEmailList = (emailList, local) => {
-  return UsersClient.getUsersV3(emailList, '', local)
-}
-
-// Look up multiple users with userIDs via https://rest-api.symphony.com/reference#users-lookup-v3
-UsersClient.getUsersFromIdList = (idList, local) => {
-  return UsersClient.getUsersV3('', idList, local)
-}
-
-UsersClient.getUsersV3 = (emailList, idList, local) => {
-  var listPart  = (emailList ? `email=${emailList}` : `uid=${idList}`);
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': `/pod/v3/users${listPart}&local=${(local ? 'true' : 'false')}`,
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'UsersClient/getUsersV3')
-}
+// Aliases for backward compatibility
+UsersClient.getUsersFromEmailList = UsersClient.getUserFromEmailV3
+UsersClient.getUsersFromIdList = UsersClient.getUserFromIdV3
 
 // Search for users using https://rest-api.symphony.com/reference#search-users
 UsersClient.searchUsers = (query, local, skip, limit, filter) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/user/search?local=' + (local ? 'true' : 'false') + '&skip=' + skip + '&limit=' + limit,
-    'method': 'POST',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
+  const body = {
+    query: query,
+    filter: filter,
   }
 
-  var body = {
-    'query': query,
-    'filter': filter
-  }
-
-  return request(options, 'UsersClient/searchUsers', body)
-
+  return podRequest(
+    'post',
+    `/pod/v1/user/search?local=${local ? 'true' : 'false'}&skip=${skip}&limit=${limit}`,
+    'UsersClient/searchUsers',
+    body
+  )
 }
 
 module.exports = UsersClient

--- a/tests/SymBotAuth/index.test.js
+++ b/tests/SymBotAuth/index.test.js
@@ -11,12 +11,10 @@ describe('SymBotAuth', () => {
       return "Contents of " + path;
     });
 
-    debugger;
-    mockHttps.request = jest.fn(() => {
-      return {
-        end: jest.fn()
-      };
-    });
+    mockHttps.request = jest.fn(() => ({
+      end: jest.fn(),
+      on: jest.fn(),
+    }));
   });
 
   afterEach(() => {


### PR DESCRIPTION
Reduce code duplication and improve consistency by factoring out shared request configuration.

Also fixed some things which I believe were bugs:
- Switch `AdminClient.importMessages` to use agent host instead of pod host
- Rename all uses of undefined property `SymBotAuth.keyManagerToken` to `SymBotAuth.kmAuthToken`
- Pass `Content-Type: application/json` header to all POST requests with JSON bodies (and only those)
- Removed duplicate implementation of  `UsersClient.getUsersFromIdList` and `UsersClient.getUsersFromEmailList`

