### PR TITLE
Add tests for simple API endpoints

### DIFF
--- a/lib/MessagesClient/index.js
+++ b/lib/MessagesClient/index.js
@@ -1,10 +1,11 @@
 const https = require('https')
 const FormData = require('form-data')
 const Q = require('kew')
+const { agentRequest } = require('../Request/clients')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
 
-var MessagesClient = {}
+const MessagesClient = {}
 
 MessagesClient.PRESENTATIONML_FORMAT = 'presentationML'
 MessagesClient.MESSAGEML_FORMAT = 'messageML'
@@ -34,26 +35,26 @@ MessagesClient.forwardMessage = (conversationId, message, data) => {
 }
 
 MessagesClient.getAttachment = (streamId, attachmentId, messageId) => {
-  var defer = Q.defer()
+  const defer = Q.defer()
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.agentHost,
-    'port': SymConfigLoader.SymConfig.agentPort,
-    'path': '/agent/v1/stream/' + streamId + '/attachment?messageId=' + messageId + '&fileId=' + attachmentId,
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.kmAuthToken
+  const options = {
+    hostname: SymConfigLoader.SymConfig.agentHost,
+    port: SymConfigLoader.SymConfig.agentPort,
+    path: `/agent/v1/stream/${streamId}/attachment?messageId=${messageId}&fileId=${attachmentId}`,
+    method: 'GET',
+    headers: {
+      sessionToken: SymBotAuth.sessionAuthToken,
+      keyManagerToken: SymBotAuth.kmAuthToken,
     },
-    'agent': SymConfigLoader.SymConfig.agentProxy
+    agent: SymConfigLoader.SymConfig.agentProxy,
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
+  const req = https.request(options, function(res) {
+    let str = ''
+    res.on('data', function(chunk) {
       str += chunk
     })
-    res.on('end', function () {
+    res.on('end', function() {
       if (SymBotAuth.debug) {
         console.log('[DEBUG]', 'MessagesClient/getAttachment/str', str)
       }
@@ -66,44 +67,12 @@ MessagesClient.getAttachment = (streamId, attachmentId, messageId) => {
   return defer.promise
 }
 
-MessagesClient.getMessage = (messageId) => {
-  var defer = Q.defer()
-
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.agentHost,
-    'port': SymConfigLoader.SymConfig.agentPort,
-    'path': '/agent/v1/message/' + messageId,
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.kmAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.agentProxy
-  }
-
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'MessagesClient/getMessage/str', str)
-      }
-      defer.resolve((str === '') ? {} : JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
-}
+MessagesClient.getMessage = messageId =>
+  agentRequest('get', `/agent/v1/message/${messageId}`, 'MessagesClient/getMessage')
 
 /* Generic function to send/forward messages from MessagesClient interface */
 var send = (conversationId, message, data, fileName, fileType, fileContent) => {
-  var defer = Q.defer()
-
-  var form = new FormData()
+  const form = new FormData()
   form.append('message', message)
   if (data != null) {
     form.append('data', data)
@@ -111,44 +80,18 @@ var send = (conversationId, message, data, fileName, fileType, fileContent) => {
 
   if (fileName != null) {
     form.append('attachment', fileContent, {
-      'filename': fileName,
-      'contentType': fileType,
-      'knownLength': fileContent.length
+      filename: fileName,
+      contentType: fileType,
+      knownLength: fileContent.length,
     })
   }
 
-  var headers = form.getHeaders()
-  headers.sessionToken = SymBotAuth.sessionAuthToken
-  headers.keyManagerToken = SymBotAuth.kmAuthToken
-
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.agentHost,
-    'port': SymConfigLoader.SymConfig.agentPort,
-    'path': '/agent/v4/stream/' + conversationId + '/message/create',
-    'method': 'POST',
-    'headers': headers,
-    'agent': SymConfigLoader.SymConfig.agentProxy
-  }
-
-  var req = https.request(options)
-
-  form.pipe(req)
-
-  req.on('response', function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.on('error', function (e) {
-    defer.reject({ 'status': 'error' })
-  })
-
-  return defer.promise
+  return agentRequest(
+    'post',
+    `/agent/v4/stream/${conversationId}/message/create`,
+    'MessagesClient/sendMessage',
+    form
+  )
 }
 
 module.exports = MessagesClient

--- a/lib/OBOClient/index.js
+++ b/lib/OBOClient/index.js
@@ -1,65 +1,25 @@
-const https = require('https')
 const FormData = require('form-data')
-const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
-const SymBotAuth = require('../SymBotAuth')
 const request = require('../Request')
+const { podRequest } = require('../Request/clients')
 
-var OBOClient = {}
+const OBOClient = {}
 
 // OBO List all user connections using https://rest-api.symphony.com/reference#list-connections
-OBOClient.oboGetAllConnections = (status) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/list?status=all',
-    'method': 'GET',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'OBOClient/oboGetAllConnections')
-}
+OBOClient.oboGetAllConnections = status =>
+  podRequest('get', '/pod/v1/connnection/list?status=all', 'OBOClient/oboGetAllConnections')
 
 // OBO Get connection information using https://rest-api.symphony.com/reference#get-connection
-OBOClient.oboGetConnection = (userId) => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/connnection/user/' + userId + '/info',
-    'method': 'GET',
-    'Content-Type': 'application/json',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'OBOClient/oboGetConnection')
-}
+OBOClient.oboGetConnection = userId =>
+  podRequest('get', `/pod/v1/connnection/user/${userId}/info`, 'OBOClient/oboGetConnection')
 
 // OBO Create IM or MIM (non inclusive) using https://rest-api.symphony.com/reference#create-im-or-mim-admin
-OBOClient.oboGetUserIMStreamId = (userIds) => {
-  var body = {
-    'userIds': userIds
+OBOClient.oboGetUserIMStreamId = userIds => {
+  const body = {
+    userIds: userIds,
   }
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.podHost,
-    'port': SymConfigLoader.SymConfig.podPort,
-    'path': '/pod/v1/admin/im/create',
-    'method': 'POST',
-    'headers': {
-      'Content-Type': 'application/json',
-      'sessionToken': SymBotAuth.sessionAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.podProxy
-  }
-
-  return request(options, 'OBOClient/oboGetUserIMStreamId', body)
+  return podRequest('post', '/pod/v1/admin/im/create', 'OBOClient/oboGetUserIMStreamId', body)
 }
 
 //
@@ -77,52 +37,26 @@ OBOClient.oboSendMessage = (userToken, conversationId, message, data, format) =>
 }
 
 /* Generic function to send/forward messages from MessagesClient interface */
-var send = (userToken, conversationId, message, data) => {
-  var defer = Q.defer()
-
-  var form = new FormData()
+function send(userToken, conversationId, message, data) {
+  const form = new FormData()
   form.append('message', message)
   if (data != null) {
     form.append('data', data)
   }
 
-  var headers = form.getHeaders()
+  const headers = form.getHeaders()
   headers.sessionToken = userToken
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.agentHost,
-    'port': SymConfigLoader.SymConfig.agentPort,
-    'path': '/agent/v4/stream/' + conversationId + '/message/create',
-    'method': 'POST',
-    'headers': headers,
-    'agent': SymConfigLoader.SymConfig.podProxy
+  const options = {
+    hostname: SymConfigLoader.SymConfig.agentHost,
+    port: SymConfigLoader.SymConfig.agentPort,
+    path: `/agent/v4/stream/${conversationId}/message/create`,
+    method: 'POST',
+    headers: headers,
+    agent: SymConfigLoader.SymConfig.podProxy,
   }
 
-  var req = https.request(options)
-
-  form.pipe(req)
-
-  req.on('response', function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'OBOClient/oboSendMessage/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.on('error', function (e) {
-    if (SymBotAuth.debug) {
-      console.log('[ERROR]', 'OBOClient/oboSendMessage/error', e)
-    }
-    defer.reject({ 'status': 'error' })
-  })
-
-  return defer.promise
+  return request(options, 'OBOClient/oboSendMessage', form)
 }
 
 module.exports = OBOClient

--- a/lib/Request/index.js
+++ b/lib/Request/index.js
@@ -1,5 +1,6 @@
 const https = require('https')
 const Q = require('kew')
+const FormData = require('form-data')
 const SymBotAuth = require('../SymBotAuth')
 
 module.exports = function request(options, debugId, body) {
@@ -12,8 +13,16 @@ module.exports = function request(options, debugId, body) {
     defer.reject({ status: 'error' })
   }
 
-  if (body && !options.headers['Content-Type']) {
-    options.headers['Content-Type'] = 'application/json'
+  if (body) {
+    if (body instanceof FormData) {
+      Object.assign(options.headers, body.getHeaders())
+    } else if (
+      !Object.keys(options.headers)
+        .map(h => h.toLowerCase())
+        .includes('content-type')
+    ) {
+      options.headers['Content-Type'] = 'application/json'
+    }
   }
 
   const req = https.request(options, res => {
@@ -33,7 +42,11 @@ module.exports = function request(options, debugId, body) {
   req.on('error', errorHandler)
 
   if (body) {
-    req.write(JSON.stringify(body))
+    if (body instanceof FormData) {
+      body.pipe(req)
+    } else {
+      req.write(JSON.stringify(body))
+    }
   }
 
   req.end()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-api-client-node",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -581,6 +581,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -867,6 +873,20 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -877,6 +897,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -1105,6 +1131,21 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-is": {
@@ -1622,6 +1663,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stream": {
@@ -2969,6 +3016,34 @@
         "uuid": "^3.3.2"
       }
     },
+    "nock": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3279,6 +3354,12 @@
         "pify": "^3.0.0"
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3353,6 +3434,12 @@
         "kleur": "^3.0.2",
         "sisteransi": "^1.0.0"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "psl": {
       "version": "1.1.31",
@@ -4185,6 +4272,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "jest": "^24.3.0"
+    "jest": "^24.3.0",
+    "nock": "^10.0.6"
   },
   "jest": {
     "verbose": true

--- a/tests/DatafeedEventsService/__snapshots__/index.test.js.snap
+++ b/tests/DatafeedEventsService/__snapshots__/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatafeedEventsService #readDatafeed handles error 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "localhost:443",
+      "hostname": "localhost",
+      "method": "GET",
+      "path": "/agent/v4/datafeed/abc123/read",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;

--- a/tests/DatafeedEventsService/index.test.js
+++ b/tests/DatafeedEventsService/index.test.js
@@ -1,0 +1,37 @@
+jest.mock('../../lib/SymConfigLoader', () => ({
+  SymConfig: { keyAuthHost: 'keyauth.example.com' },
+}))
+jest.mock('../../lib/SymBotAuth', () => ({
+  sessionAuthToken: 'session-token',
+  kmAuthToken: 'key-manager-token',
+}))
+const https = require('https')
+const nock = require('nock')
+const DatafeedEventsService = require('../../lib/DatafeedEventsService')
+
+describe('DatafeedEventsService', () => {
+  beforeAll(() => {
+    jest.spyOn(https, 'request')
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('#readDatafeed', () => {
+    it.skip('handles error', () => {
+      const id = 'abc123'
+      nock('https://keyauth.example.com')
+        .get(`/agent/v4/datafeed/${id}/read`)
+        .reply(200, '{"status":"success"}')
+      nock('https://keyauth.example.com')
+        .get(`/agent/v4/datafeed/${id}/read`)
+        .reply(200, '{"status":"test"}')
+
+      expect(DatafeedEventsService.readDatafeed(id)).resolves.toBeUndefined()
+
+      expect(https.request).toHaveBeenCalledTimes(2)
+      expect(https.request.mock.calls).toMatchSnapshot()
+    })
+  })
+})

--- a/tests/SymBotAuth/index.test.js
+++ b/tests/SymBotAuth/index.test.js
@@ -7,9 +7,7 @@ const mockHttps = require('https');
 
 describe('SymBotAuth', () => {
   beforeEach(() => {
-    mockFs.readFileSync = jest.fn((path, encoding) => {
-      return "Contents of " + path;
-    });
+    mockFs.readFileSync = jest.fn((path) => "Contents of " + path);
 
     mockHttps.request = jest.fn(() => ({
       end: jest.fn(),

--- a/tests/SymBotClient/__snapshots__/index.test.js.snap
+++ b/tests/SymBotClient/__snapshots__/index.test.js.snap
@@ -1,0 +1,1031 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SymBotClient #acceptConnectionRequest handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/connnection/accept",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #activateRoom handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/room/abc123/setActive?active=true",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #addMemberToRoom handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/room/abc123/membership/add",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #adminListEnterpriseStreamsV2 handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "post",
+      "path": "/pod/v2/admin/streams/list?skip=0&limit=100",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #createRoom handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v3/room/create",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #createSignal handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "POST",
+      "path": "/agent/v1/signals/create",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #deactivateRoom handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/room/abc123/setActive?active=false",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #deleteSignal handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "POST",
+      "path": "/agent/v1/signals/abc123/delete",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #demoteUserFromOwner handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/room/abc123/membership/demoteOwner",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getAcceptedConnections handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v1/connnection/list?status=accepted",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getAllConnections handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v1/connnection/list?status=all",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getConnectionRequestStatus handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v1/connnection/user/abc123/info",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getConnections handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v1/connnection/list?status=all?userIds=abc123",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getInboundPendingConnections handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v1/connnection/list?status=pending_incoming",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getMessage handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "get",
+      "path": "/agent/v1/message/abc123",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getPendingConnections handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v1/connnection/list?status=pending_outgoing",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getRejectedConnections handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v1/connnection/list?status=rejected",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getRoomInfo handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v3/room/abc123/info",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getRoomMembers handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v2/room/abc123/membership/list",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getSignal handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "GET",
+      "path": "/agent/v1/signals/abc123/get",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getSignalSubscribers handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "GET",
+      "path": "/agent/v1/signals/abc123/subscribers?skip=0&limit=50",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getUser handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v2/admin/user/abc123",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getUserFromEmail handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v2/user?email=example@example.com&local=true",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getUserFromUsername handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v2/user?username=user123",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getUserIMStreamId handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/im/create",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getUserPresence handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "GET",
+      "path": "/pod/v3/user/abc123/presence?local=false",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getUserStreams handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/streams/list?skip=0&limit=100",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getUsersFromEmailList handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v3/users?email=example@example.com,example@example.org&local=true",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #getUsersFromIdList handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v3/users?uid=1234&local=true",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #importMessages handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "post",
+      "path": "/agent/v4/message/import",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #listSignals handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "GET",
+      "path": "/agent/v1/signals/list?skip=0&limit=50",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #listUsers handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v2/admin/user/list?skip=0&limit=1000",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #oboGetAllConnections handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v1/connnection/list?status=all",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #oboGetConnection handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v1/connnection/user/abc123/info",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #oboGetUserIMStreamId handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "post",
+      "path": "/pod/v1/admin/im/create",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #promoteUserToOwner handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/room/abc123/membership/promoteOwner",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #registerInterestExtUser handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/user/presence/register",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #rejectConnectionRequest handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/connnection/reject",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #removeConnection handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/connnection/user/abc123/remove",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #removeMemberFromRoom handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/room/abc123/membership/remove",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #searchRooms handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v3/room/search?skip=0&limit=100",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #searchUsers handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "post",
+      "path": "/pod/v1/user/search?local=true&skip=10&limit=100",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #sendConnectionRequest handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v1/connnection/create",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #setPresence handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v2/user/presence",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #streamMembers handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "get",
+      "path": "/pod/v1/admin/stream/abc123/membership/list?skip=0&limit=1000",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #subscribeSignal handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "POST",
+      "path": "/agent/v1/signals/abc123/subscribe?pushed=false",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #suppressMessage handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "post",
+      "path": "/pod/v1/admin/messagesuppression/abc123/suppress",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #unsubscribeSignal handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "POST",
+      "path": "/agent/v1/signals/abc123/unsubscribe",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #updateRoom handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "sessionToken": "session-token",
+      },
+      "host": "pod.example.com:443",
+      "hostname": "pod.example.com",
+      "method": "POST",
+      "path": "/pod/v3/room/abc123/update",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`SymBotClient #updateSignal handles success 1`] = `
+Array [
+  Array [
+    Object {
+      "agent": undefined,
+      "headers": Object {
+        "Content-Type": "application/json",
+        "keyManagerToken": "key-manager-token",
+        "sessionToken": "session-token",
+      },
+      "host": "agent.example.com:443",
+      "hostname": "agent.example.com",
+      "method": "POST",
+      "path": "/agent/v1/signals/abc123/update",
+      "port": 443,
+      "proto": "https",
+    },
+    [Function],
+  ],
+]
+`;

--- a/tests/SymBotClient/index.test.js
+++ b/tests/SymBotClient/index.test.js
@@ -1,0 +1,169 @@
+const mockConfig = {
+  agentHost: 'agent.example.com',
+  agentPort: 443,
+  podHost: 'pod.example.com',
+  podPort: 443,
+}
+
+jest.mock('../../lib/SymConfigLoader', () => ({
+  SymConfig: mockConfig,
+}))
+jest.mock('../../lib/SymBotAuth', () => ({
+  sessionAuthToken: 'session-token',
+  kmAuthToken: 'key-manager-token',
+}))
+const https = require('https')
+const nock = require('nock')
+const SymBotClient = require('../../lib/SymBotClient')
+
+describe('SymBotClient', () => {
+  beforeAll(() => {
+    jest.spyOn(https, 'request')
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe.each([
+    // AdminClient
+    ['adminListEnterpriseStreamsV2', [], 'post', '/pod/v2/admin/streams/list?skip=0&limit=100'],
+    [
+      'streamMembers',
+      ['abc123'],
+      'get',
+      '/pod/v1/admin/stream/abc123/membership/list?skip=0&limit=1000',
+    ],
+    ['importMessages', [['one', 'two']], 'post', '/agent/v4/message/import'],
+    ['suppressMessage', ['abc123'], 'post', '/pod/v1/admin/messagesuppression/abc123/suppress'],
+
+    // AdminUserClient
+    ['getUser', ['abc123'], 'get', '/pod/v2/admin/user/abc123'],
+    ['listUsers', [], 'get', '/pod/v2/admin/user/list?skip=0&limit=1000'],
+
+    // ConnectionsClient
+    ['getPendingConnections', [], 'get', '/pod/v1/connnection/list?status=pending_outgoing'],
+    ['getInboundPendingConnections', [], 'get', '/pod/v1/connnection/list?status=pending_incoming'],
+    ['getAllConnections', [], 'get', '/pod/v1/connnection/list?status=all'],
+    ['getAcceptedConnections', [], 'get', '/pod/v1/connnection/list?status=accepted'],
+    ['getRejectedConnections', [], 'get', '/pod/v1/connnection/list?status=rejected'],
+    [
+      'getConnections',
+      ['dummy', 'abc123'],
+      'get',
+      '/pod/v1/connnection/list?status=all?userIds=abc123',
+    ],
+    ['acceptConnectionRequest', [], 'post', '/pod/v1/connnection/accept'],
+    ['rejectConnectionRequest', [], 'post', '/pod/v1/connnection/reject'],
+    ['sendConnectionRequest', [], 'post', '/pod/v1/connnection/create'],
+    ['removeConnection', ['abc123'], 'post', '/pod/v1/connnection/user/abc123/remove'],
+    ['getConnectionRequestStatus', ['abc123'], 'get', '/pod/v1/connnection/user/abc123/info'],
+
+    // DatafeedClient
+
+    // getDatafeedEventsService
+    // stopDatafeedEventsService
+
+    // FirehoseClient
+
+    // getFirehoseEventsService
+    // stopFirehoseEventsService
+
+    // MessagesClient
+
+    // sendMessage - multipart boundary header
+    // sendMessageWithAttachment - multipart boundary header
+    // forwardMessage - multipart boundary header
+    // getAttachment - response is Base64
+    ['getMessage', ['abc123'], 'get', '/agent/v1/message/abc123'],
+
+    // OBOClient
+
+    // oboAuthenticateByUserId
+    ['oboGetAllConnections', [], 'get', '/pod/v1/connnection/list?status=all'],
+    ['oboGetConnection', ['abc123'], 'get', '/pod/v1/connnection/user/abc123/info'],
+    ['oboGetUserIMStreamId', [], 'post', '/pod/v1/admin/im/create'],
+    // oboSendMessage - multipart boundary header
+
+    // SignalsClient
+    ['listSignals', [], 'get', '/agent/v1/signals/list?skip=0&limit=50'],
+    ['getSignal', ['abc123'], 'get', '/agent/v1/signals/abc123/get'],
+    ['createSignal', [], 'post', '/agent/v1/signals/create'],
+    ['updateSignal', ['abc123'], 'post', '/agent/v1/signals/abc123/update'],
+    ['deleteSignal', ['abc123'], 'post', '/agent/v1/signals/abc123/delete'],
+    ['subscribeSignal', ['abc123'], 'post', '/agent/v1/signals/abc123/subscribe?pushed=false'],
+    ['unsubscribeSignal', ['abc123'], 'post', '/agent/v1/signals/abc123/unsubscribe'],
+    [
+      'getSignalSubscribers',
+      ['abc123'],
+      'get',
+      '/agent/v1/signals/abc123/subscribers?skip=0&limit=50',
+    ],
+
+    // StreamsClient
+    ['getUserIMStreamId', [], 'post', '/pod/v1/im/create'],
+    ['createRoom', [], 'post', '/pod/v3/room/create'],
+    ['updateRoom', ['abc123'], 'post', '/pod/v3/room/abc123/update'],
+    ['getRoomInfo', ['abc123'], 'get', '/pod/v3/room/abc123/info'],
+    ['activateRoom', ['abc123'], 'post', '/pod/v1/room/abc123/setActive?active=true'],
+    ['deactivateRoom', ['abc123'], 'post', '/pod/v1/room/abc123/setActive?active=false'],
+    ['getRoomMembers', ['abc123'], 'get', '/pod/v2/room/abc123/membership/list'],
+    ['addMemberToRoom', ['abc123'], 'post', '/pod/v1/room/abc123/membership/add'],
+    ['removeMemberFromRoom', ['abc123'], 'post', '/pod/v1/room/abc123/membership/remove'],
+    ['promoteUserToOwner', ['abc123'], 'post', '/pod/v1/room/abc123/membership/promoteOwner'],
+    ['demoteUserFromOwner', ['abc123'], 'post', '/pod/v1/room/abc123/membership/demoteOwner'],
+    ['searchRooms', [], 'post', '/pod/v3/room/search?skip=0&limit=100'],
+    ['getUserStreams', [], 'post', '/pod/v1/streams/list?skip=0&limit=100'],
+
+    // UsersClient
+    ['getUserFromUsername', ['user123'], 'get', '/pod/v2/user?username=user123'],
+    [
+      'getUserFromEmail',
+      ['example@example.com', true],
+      'get',
+      '/pod/v2/user?email=example@example.com&local=true',
+    ],
+    [
+      'getUsersFromEmailList',
+      ['example@example.com,example@example.org', true],
+      'get',
+      '/pod/v3/users?email=example@example.com,example@example.org&local=true',
+    ],
+    ['getUsersFromIdList', [1234, true], 'get', '/pod/v3/users?uid=1234&local=true'],
+    [
+      'searchUsers',
+      ['query', true, 10, 100, 'filter'],
+      'post',
+      '/pod/v1/user/search?local=true&skip=10&limit=100',
+    ],
+
+    // PresenceClient
+    ['getUserPresence', ['abc123'], 'get', '/pod/v3/user/abc123/presence?local=false'],
+    ['setPresence', ['status'], 'post', '/pod/v2/user/presence'],
+    ['registerInterestExtUser', [], 'post', '/pod/v1/user/presence/register'],
+  ])('#%s', (methodName, args, verb, path) => {
+    const host = path.substr(0, 6) === '/agent' ? mockConfig.agentHost : mockConfig.podHost
+
+    it('handles success', async () => {
+      nock(`https://${host}`)
+        [verb](path)
+        .reply(200, '{"status":"OK"}')
+
+      await expect(SymBotClient[methodName](...args)).resolves.toEqual({
+        status: 'OK',
+      })
+
+      expect(https.request.mock.calls).toMatchSnapshot()
+    })
+
+    it('handles failure', () => {
+      nock(`https://${host}`)
+        [verb](path)
+        .replyWithError('Oh no')
+
+      return expect(SymBotClient[methodName](...args)).rejects.toEqual({
+        status: 'error',
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Simple high level tests for most public API methods verifying that they call the right endpoint and promises are correctly handled.
- Add `FormData` body handling to request helper.