### PR TITLE
Fix malformed proxy URL when proxy username and password is given.

### DIFF
--- a/lib/SymConfigLoader/index.js
+++ b/lib/SymConfigLoader/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const Q = require('kew')
 const HttpsProxyAgent = require('https-proxy-agent')
+const url = require('url');
 
 var SymConfigLoader = {}
 
@@ -42,9 +43,9 @@ SymConfigLoader.loadFromFile = (path) => {
       if (config[urlKey]) {
         let proxyURI
         if (config[usernameKey]) {
-          const endpoint = config[urlKey].substring(config[urlKey].indexOf('://') + 3)
-          const protocol = config[urlKey].substring(0, config[urlKey].indexOf('://'))
-          proxyURI = protocol + config[usernameKey] + ':' + config[passwordKey] + '@' + endpoint
+          const proxyUrl = url.parse(config[urlKey]);
+          proxyUrl.auth = `${config[usernameKey]}:${config[passwordKey]}`;
+          proxyURI = url.format(proxyUrl);
         } else {
           proxyURI = config[urlKey]
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-api-client-node",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/SymConfigLoader/index.test.js
+++ b/tests/SymConfigLoader/index.test.js
@@ -6,7 +6,7 @@ const mockFs = require('fs');
 describe('SymConfigLoader', () => {
 
   afterEach(() => {
-    jest.resetModules();
+    jest.clearAllMocks();
   });
 
   describe('proxy config', () => {

--- a/tests/SymConfigLoader/index.test.js
+++ b/tests/SymConfigLoader/index.test.js
@@ -1,0 +1,174 @@
+const SymConfigLoader = require('../../lib/SymConfigLoader');
+
+jest.mock('fs');
+const mockFs = require('fs');
+
+describe('SymConfigLoader', () => {
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  describe('proxy config', () => {
+    describe('agent proxy', () => {
+      it('should create a proxy', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            proxyURL: 'https://agent-proxy-url/',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.agentProxy.proxy.href).toEqual('https://agent-proxy-url/');
+        });
+      });
+
+      it('should create an authenticated proxy', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            proxyURL: 'https://agent-proxy-url/',
+            proxyUsername: 'test-user',
+            proxyPassword: 'test-pass',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.agentProxy.proxy.href).toEqual(
+            'https://test-user:test-pass@agent-proxy-url/'
+          );
+        });
+      });
+
+      it('should encode special characters', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            proxyURL: 'https://agent-proxy-url/',
+            proxyUsername: 'test-user-$%',
+            proxyPassword: 'test-pass-$%',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.agentProxy.proxy.href).toEqual(
+            'https://test-user-%24%25:test-pass-%24%25@agent-proxy-url/'
+          );
+        });
+      });
+    });
+
+    describe('pod proxy', () => {
+      it('should create a proxy', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            proxyURL: 'https://pod-proxy-url/',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.podProxy.proxy.href).toEqual('https://pod-proxy-url/');
+        });
+      });
+
+      it('should create an authenticated proxy', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            proxyURL: 'https://pod-proxy-url/',
+            proxyUsername: 'test-user',
+            proxyPassword: 'test-pass',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.podProxy.proxy.href).toEqual(
+            'https://test-user:test-pass@pod-proxy-url/'
+          );
+        });
+      });
+
+      it('should encode special characters', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            proxyURL: 'https://pod-proxy-url/',
+            proxyUsername: 'test-user-$%',
+            proxyPassword: 'test-pass-$%',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.podProxy.proxy.href).toEqual(
+            'https://test-user-%24%25:test-pass-%24%25@pod-proxy-url/'
+          );
+        });
+      });
+
+      it('should create a proxy for only the pod', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            podProxyURL: 'https://pod-proxy-url/',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.podProxy.proxy.href).toEqual('https://pod-proxy-url/');
+          expect(config.agentProxy).toBeUndefined();
+        });
+      });
+    });
+
+    describe('keyManager proxy', () => {
+      it('should create a proxy', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            keyManagerProxyURL: 'https://km-proxy-url/',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.keyManagerProxy.proxy.href).toEqual('https://km-proxy-url/');
+        });
+      });
+
+      it('should create an authenticated proxy', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            keyManagerProxyURL: 'https://km-proxy-url/',
+            keyManagerProxyUsername: 'test-user',
+            keyManagerProxyPassword: 'test-pass',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.keyManagerProxy.proxy.href).toEqual(
+            'https://test-user:test-pass@km-proxy-url/'
+          );
+        });
+      });
+
+      it('should encode special characters', () => {
+        mockFs.readFile = jest.fn((path, cb) => {
+          return cb(null, JSON.stringify({
+            keyManagerProxyURL: 'https://km-proxy-url/',
+            keyManagerProxyUsername: 'test-user-$%',
+            keyManagerProxyPassword: 'test-pass-$%',
+          }))
+        });
+
+        return SymConfigLoader.loadFromFile('a-path').then(config => {
+          expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.keyManagerProxy.proxy.href).toEqual(
+            'https://test-user-%24%25:test-pass-%24%25@km-proxy-url/'
+          );
+        });
+      });
+    });
+  });
+});

--- a/tests/SymConfigLoader/index.test.js
+++ b/tests/SymConfigLoader/index.test.js
@@ -11,7 +11,7 @@ describe('SymConfigLoader', () => {
 
   describe('proxy config', () => {
     describe('agent proxy', () => {
-      it('should create a proxy', () => {
+      it('creates a proxy', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             proxyURL: 'https://agent-proxy-url/',
@@ -24,7 +24,7 @@ describe('SymConfigLoader', () => {
         });
       });
 
-      it('should create an authenticated proxy', () => {
+      it('creates an authenticated proxy', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             proxyURL: 'https://agent-proxy-url/',
@@ -41,7 +41,7 @@ describe('SymConfigLoader', () => {
         });
       });
 
-      it('should encode special characters', () => {
+      it('encodes special characters', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             proxyURL: 'https://agent-proxy-url/',
@@ -60,7 +60,7 @@ describe('SymConfigLoader', () => {
     });
 
     describe('pod proxy', () => {
-      it('should create a proxy', () => {
+      it('creates a proxy', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             proxyURL: 'https://pod-proxy-url/',
@@ -73,7 +73,7 @@ describe('SymConfigLoader', () => {
         });
       });
 
-      it('should create an authenticated proxy', () => {
+      it('creates an authenticated proxy', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             proxyURL: 'https://pod-proxy-url/',
@@ -90,7 +90,7 @@ describe('SymConfigLoader', () => {
         });
       });
 
-      it('should encode special characters', () => {
+      it('encodes special characters', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             proxyURL: 'https://pod-proxy-url/',
@@ -107,7 +107,7 @@ describe('SymConfigLoader', () => {
         });
       });
 
-      it('should create a proxy for only the pod', () => {
+      it('creates a proxy for only the pod', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             podProxyURL: 'https://pod-proxy-url/',
@@ -123,7 +123,7 @@ describe('SymConfigLoader', () => {
     });
 
     describe('keyManager proxy', () => {
-      it('should create a proxy', () => {
+      it('creates a proxy', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             keyManagerProxyURL: 'https://km-proxy-url/',
@@ -136,7 +136,7 @@ describe('SymConfigLoader', () => {
         });
       });
 
-      it('should create an authenticated proxy', () => {
+      it('creates an authenticated proxy', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             keyManagerProxyURL: 'https://km-proxy-url/',
@@ -153,7 +153,7 @@ describe('SymConfigLoader', () => {
         });
       });
 
-      it('should encode special characters', () => {
+      it('encodes special characters', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
             keyManagerProxyURL: 'https://km-proxy-url/',


### PR DESCRIPTION
The resulting proxy url when username and password where given had '://' missing from it.
Also added support for special characters in the proxy username and password by switching url manipulation to the 'url' package. This package is already in use by the https-proxy-agent dependency.