### PR TITLE
Fix bug with form-data requests

### DIFF
--- a/lib/DatafeedClient/index.js
+++ b/lib/DatafeedClient/index.js
@@ -1,94 +1,50 @@
-const https = require('https')
-const Q = require('kew')
 const PubSub = require('pubsub-js')
 const SymBotAuth = require('../SymBotAuth')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymMessageParser = require('../SymMessageParser')
+const request = require('../Request')
+const { agentRequest } = require('../Request/clients')
 
-var DatafeedClient = {}
+const DatafeedClient = {}
 
 DatafeedClient.registerBot = (token) => {
   DatafeedClient.psToken = token
 }
 
-DatafeedClient.createDatafeed = () => {
-  var defer = Q.defer()
+DatafeedClient.createDatafeed = () =>
+  agentRequest('post', '/agent/v4/datafeed/create', 'DatafeedClient/createDatafeed')
 
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.agentHost,
-    'port': SymConfigLoader.SymConfig.agentPort,
-    'path': '/agent/v4/datafeed/create',
-    'method': 'POST',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.kmAuthToken
+DatafeedClient.getEventsFromDatafeed = datafeedId => {
+  const options = {
+    hostname: SymConfigLoader.SymConfig.agentHost,
+    port: SymConfigLoader.SymConfig.agentPort,
+    path: `/agent/v4/datafeed/${datafeedId}/read`,
+    method: 'GET',
+    headers: {
+      sessionToken: SymBotAuth.sessionAuthToken,
+      keyManagerToken: SymBotAuth.kmAuthToken,
     },
-    'agent': SymConfigLoader.SymConfig.agentProxy
+    agent: SymConfigLoader.SymConfig.agentProxy,
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'DatafeedClient/createDatafeed/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
+  return request(options, 'DatafeedClient/getEventsFromDatafeed', null, true).then(response => {
+    if (SymBotAuth.debug) {
+      console.log(
+        '[DEBUG]',
+        'DatafeedClient/getEventsFromDatafeed/res.statusCode',
+        response.statusCode
+      )
+    }
+
+    if (response.statusCode === 200) {
+      PubSub.publish('MESSAGE_RECEIVED', SymMessageParser.parse(response.body))
+      return { status: 'success' }
+    } else if (response.statusCode === 204) {
+      return { status: 'timeout' }
+    } else {
+      throw { status: 'error' }
+    }
   })
-  req.on('error', function (e) {
-    console.log('error', e)
-  })
-
-  req.end()
-
-  return defer.promise
-}
-
-DatafeedClient.getEventsFromDatafeed = (datafeedId) => {
-  var defer = Q.defer()
-
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.agentHost,
-    'port': SymConfigLoader.SymConfig.agentPort,
-    'path': '/agent/v4/datafeed/' + datafeedId + '/read',
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.kmAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.agentProxy
-  }
-
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'DatafeedClient/getEventsFromDatafeed/res.statusCode', res.statusCode)
-        console.log('[DEBUG]', 'DatafeedClient/getEventsFromDatafeed/str', str)
-      }
-      if (res.statusCode === 200) {
-        PubSub.publish('MESSAGE_RECEIVED', SymMessageParser.parse(str))
-        defer.resolve({ 'status': 'success' })
-      } else if (res.statusCode === 204) {
-        defer.resolve({ 'status': 'timeout' })
-      } else {
-        defer.reject({ 'status': 'error' })
-      }
-    })
-  })
-  req.on('error', function (e) {
-    defer.reject({ 'status': 'error' })
-  })
-
-  req.end()
-
-  return defer.promise
 }
 
 module.exports = DatafeedClient

--- a/lib/FirehoseClient/index.js
+++ b/lib/FirehoseClient/index.js
@@ -1,77 +1,50 @@
-const https = require('https')
-const Q = require('kew')
 const PubSub = require('pubsub-js')
 const SymBotAuth = require('../SymBotAuth')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymMessageParser = require('../SymMessageParser')
 const request = require('../Request')
+const { agentRequest } = require('../Request/clients')
 
-var FirehoseClient = {}
+const FirehoseClient = {}
 
-FirehoseClient.registerBot = (token) => {
+FirehoseClient.registerBot = token => {
   FirehoseClient.psToken = token
 }
 
 // Create Firehose v1.0 using https://rest-api.symphony.com/v1.53/reference?showHidden=1a1dd#create-firehose-v4
-FirehoseClient.createFirehose = () => {
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.agentHost,
-    'port': SymConfigLoader.SymConfig.agentPort,
-    'path': '/agent/v4/firehose/create',
-    'method': 'POST',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.kmAuthToken
-    },
-    'agent': SymConfigLoader.SymConfig.agentProxy
-  }
-
-  return request(options, 'FirehoseClient/createFirehose')
-}
+FirehoseClient.createFirehose = () =>
+  agentRequest('post', '/agent/v4/firehose/create', 'FirehoseClient/createFirehose')
 
 // Read Firehose v1.0 using https://rest-api.symphony.com/v1.53/reference?showHidden=1a1dd#read-firehose-v4
-FirehoseClient.getEventsFromFirehose = (firehoseId) => {
-  var defer = Q.defer()
-
-  var options = {
-    'hostname': SymConfigLoader.SymConfig.agentHost,
-    'port': SymConfigLoader.SymConfig.agentPort,
-    'path': '/agent/v4/firehose/' + firehoseId + '/read',
-    'method': 'GET',
-    'headers': {
-      'sessionToken': SymBotAuth.sessionAuthToken,
-      'keyManagerToken': SymBotAuth.kmAuthToken
+FirehoseClient.getEventsFromFirehose = firehoseId => {
+  const options = {
+    hostname: SymConfigLoader.SymConfig.agentHost,
+    port: SymConfigLoader.SymConfig.agentPort,
+    path: `/agent/v4/firehose/${firehoseId}/read`,
+    method: 'GET',
+    headers: {
+      sessionToken: SymBotAuth.sessionAuthToken,
+      keyManagerToken: SymBotAuth.kmAuthToken,
     },
-    'agent': SymConfigLoader.SymConfig.agentProxy
+    agent: SymConfigLoader.SymConfig.agentProxy,
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'FirehoseClient/getEventsFromFirehose/res.statusCode', res.statusCode)
-        console.log('[DEBUG]', 'FirehoseClient/getEventsFromFirehouse/str', str)
-      }
-      if (res.statusCode === 200) {
-        PubSub.publish('FIREHOSE: MESSAGE_RECEIVED', SymMessageParser.parse(str))
-        defer.resolve({ 'status': 'success' })
-      } else if (res.statusCode === 204) {
-        defer.resolve({ 'status': 'timeout' })
-      } else {
-        defer.reject({ 'status': 'error' })
-      }
-    })
-  })
-  req.on('error', function (e) {
-    defer.reject({ 'status': 'error' })
-  })
+  return request(options, 'FirehoseClient/getEventsFromFirehouse', null, true).then(response => {
+    console.log(
+      '[DEBUG]',
+      'FirehoseClient/getEventsFromFirehose/res.statusCode',
+      response.statusCode
+    )
 
-  req.end()
-
-  return defer.promise
+    if (response.statusCode === 200) {
+      PubSub.publish('FIREHOSE: MESSAGE_RECEIVED', SymMessageParser.parse(response.body))
+      return { status: 'success' }
+    } else if (response.statusCode === 204) {
+      return { status: 'timeout' }
+    } else {
+      throw { status: 'error' }
+    }
+  })
 }
 
 module.exports = FirehoseClient

--- a/lib/MessagesClient/index.js
+++ b/lib/MessagesClient/index.js
@@ -1,6 +1,5 @@
-const https = require('https')
 const FormData = require('form-data')
-const Q = require('kew')
+const request = require('../Request')
 const { agentRequest } = require('../Request/clients')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
@@ -20,7 +19,15 @@ MessagesClient.sendMessage = (conversationId, message, data, format) => {
   }
 }
 
-MessagesClient.sendMessageWithAttachment = (conversationId, message, data, fileName, fileType, fileContent, format) => {
+MessagesClient.sendMessageWithAttachment = (
+  conversationId,
+  message,
+  data,
+  fileName,
+  fileType,
+  fileContent,
+  format
+) => {
   if (format === MessagesClient.PRESENTATIONML_FORMAT) {
     message = '<div data-format="PresentationML" data-version="2.0">' + message + '</div>'
     return send(conversationId, message, data, fileName, fileType, fileContent)
@@ -35,8 +42,6 @@ MessagesClient.forwardMessage = (conversationId, message, data) => {
 }
 
 MessagesClient.getAttachment = (streamId, attachmentId, messageId) => {
-  const defer = Q.defer()
-
   const options = {
     hostname: SymConfigLoader.SymConfig.agentHost,
     port: SymConfigLoader.SymConfig.agentPort,
@@ -49,29 +54,16 @@ MessagesClient.getAttachment = (streamId, attachmentId, messageId) => {
     agent: SymConfigLoader.SymConfig.agentProxy,
   }
 
-  const req = https.request(options, function(res) {
-    let str = ''
-    res.on('data', function(chunk) {
-      str += chunk
-    })
-    res.on('end', function() {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'MessagesClient/getAttachment/str', str)
-      }
-      defer.resolve(Buffer.from(str, 'base64'))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'MessagesClient/getAttachment', null, true).then(response =>
+    Buffer.from(response.body, 'base64')
+  )
 }
 
 MessagesClient.getMessage = messageId =>
   agentRequest('get', `/agent/v1/message/${messageId}`, 'MessagesClient/getMessage')
 
 /* Generic function to send/forward messages from MessagesClient interface */
-var send = (conversationId, message, data, fileName, fileType, fileContent) => {
+function send(conversationId, message, data, fileName, fileType, fileContent) {
   const form = new FormData()
   form.append('message', message)
   if (data != null) {

--- a/lib/Request/index.js
+++ b/lib/Request/index.js
@@ -3,7 +3,7 @@ const Q = require('kew')
 const FormData = require('form-data')
 const SymBotAuth = require('../SymBotAuth')
 
-module.exports = function request(options, debugId, body) {
+module.exports = function request(options, debugId, body = null, fullResponse = false) {
   const defer = Q.defer()
 
   const errorHandler = err => {
@@ -11,6 +11,10 @@ module.exports = function request(options, debugId, body) {
       console.log('[ERROR]', debugId + '/err', err)
     }
     defer.reject({ status: 'error' })
+  }
+
+  if (!options.headers) {
+    options.headers = {}
   }
 
   if (body) {
@@ -34,22 +38,36 @@ module.exports = function request(options, debugId, body) {
       if (SymBotAuth.debug) {
         console.log('[DEBUG]', debugId + '/str', str)
       }
-      defer.resolve(str === '' ? {} : JSON.parse(str))
+
+      if (fullResponse) {
+        defer.resolve({
+          statusCode: res.statusCode,
+          headers: res.headers,
+          body: str,
+        })
+      } else {
+        defer.resolve(str === '' ? {} : JSON.parse(str))
+      }
     })
     res.on('error', errorHandler)
   })
 
   req.on('error', errorHandler)
+  req.setTimeout(60000, () => {
+    if (SymBotAuth.debug) {
+      console.log('[DEBUG]', debugId + '/timeout')
+    }
+    req.abort()
+  })
 
-  if (body) {
-    if (body instanceof FormData) {
-      body.pipe(req)
-    } else {
+  if (body && body instanceof FormData) {
+    body.pipe(req)
+  } else {
+    if (body) {
       req.write(JSON.stringify(body))
     }
+    req.end()
   }
-
-  req.end()
 
   return defer.promise
 }

--- a/tests/Request/index.test.js
+++ b/tests/Request/index.test.js
@@ -1,0 +1,125 @@
+const nock = require('nock')
+const FormData = require('form-data')
+const request = require('../../lib/Request')
+
+describe('Request helper', () => {
+  afterAll(() => nock.isDone())
+
+  it('handles JSON response', async () => {
+    nock('https://example.com')
+      .get('/test')
+      .reply(200, '{"test":"body"}')
+    const body = await request({ host: 'example.com', path: '/test' })
+    expect(body).toEqual({ test: 'body' })
+  })
+
+  it('handles empty response', async () => {
+    nock('https://example.com')
+      .get('/test')
+      .reply(200, '')
+    const body = await request({ host: 'example.com', path: '/test' })
+    expect(body).toEqual({})
+  })
+
+  it('sends JSON body', async () => {
+    const requestBody = { some: 'body' }
+    nock('https://example.com')
+      .post('/test', requestBody)
+      .reply(200, '')
+
+    const responseBody = await request(
+      { host: 'example.com', path: '/test', method: 'post' },
+      '',
+      requestBody
+    )
+    expect(responseBody).toEqual({})
+  })
+
+  it('sends form-data body', async () => {
+    const form = new FormData()
+    form.append('test', 'value')
+    nock('https://example.com')
+      .post('/test', /\r\nContent-Disposition: form-data; name="test"\r\n\r\nvalue\r\n---/)
+      .reply(200, '')
+
+    const responseBody = await request(
+      { host: 'example.com', path: '/test', method: 'post' },
+      '',
+      form
+    )
+    expect(responseBody).toEqual({})
+  })
+
+  it('adds JSON content-type header', async () => {
+    const requestBody = { some: 'body' }
+    nock('https://example.com', { reqheaders: { 'content-type': 'application/json' } })
+      .post('/test', requestBody)
+      .reply(200, '')
+
+    const responseBody = await request(
+      { host: 'example.com', path: '/test', method: 'post' },
+      '',
+      requestBody
+    )
+    expect(responseBody).toEqual({})
+  })
+
+  it('does not add content-type header if present', async () => {
+    const requestBody = { some: 'body' }
+    nock('https://example.com', { reqheaders: { 'content-type': 'foo' } })
+      .post('/test', requestBody)
+      .reply(200, '')
+
+    const responseBody = await request(
+      { host: 'example.com', path: '/test', method: 'post', headers: { 'content-Type': 'foo' } },
+      '',
+      requestBody
+    )
+    expect(responseBody).toEqual({})
+  })
+
+  it('resolves with full response', async () => {
+    nock('https://example.com')
+      .get('/test')
+      .reply(200, 'hello', { 'Content-Type': 'text/plain' })
+
+    const response = await request({ host: 'example.com', path: '/test' }, '', null, true)
+    expect(response).toEqual({
+      statusCode: 200,
+      headers: { 'content-type': 'text/plain' },
+      body: 'hello',
+    })
+  })
+
+  // TODO make this change to client behaviour in next major version
+  it.skip('rejects on HTTP errors', () => {
+    nock('https://example.com')
+      .get('/test')
+      .reply(400, '{"test":"body"}')
+
+    return expect(request({ host: 'example.com', path: '/test' })).rejects.toEqual({
+      status: 'error',
+    })
+  })
+
+  it('handles request error', () => {
+    nock('https://example.com')
+      .get('/test')
+      .replyWithError('Oh no')
+
+    return expect(request({ host: 'example.com', path: '/test' })).rejects.toEqual({
+      status: 'error',
+    })
+  })
+
+  it('handles socket timeout', () => {
+    nock('https://example.com')
+      .get('/test')
+      .socketDelay(70000)
+      .reply(200, '')
+
+    return expect(request({ host: 'example.com', path: '/test' })).rejects.toEqual({
+      status: 'error',
+    })
+  })
+})

--- a/tests/SymBotAuth/__snapshots__/index.test.js.snap
+++ b/tests/SymBotAuth/__snapshots__/index.test.js.snap
@@ -5,6 +5,7 @@ Array [
   Array [
     Object {
       "agent": "agent",
+      "headers": Object {},
       "hostname": "https://key.example.com",
       "method": "POST",
       "passphrase": "Passphrase",
@@ -22,6 +23,7 @@ Array [
   Array [
     Object {
       "agent": "agent",
+      "headers": Object {},
       "hostname": "https://session.example.com",
       "method": "POST",
       "passphrase": "Passphrase",

--- a/tests/SymBotAuth/index.test.js
+++ b/tests/SymBotAuth/index.test.js
@@ -12,6 +12,7 @@ describe('SymBotAuth', () => {
     mockHttps.request = jest.fn(() => ({
       end: jest.fn(),
       on: jest.fn(),
+      setTimeout: jest.fn()
     }));
   });
 

--- a/tests/symphony-api-client.test.js
+++ b/tests/symphony-api-client.test.js
@@ -4,38 +4,43 @@ var testContext = {};
 
 jest.setTimeout(15000);
 
-beforeAll(() => {
-  return SymBotClient.initBot( __dirname + '/../config.json' ).then(data => {
-    testContext.symAuth = data;
-  })
-});
+describe('Bot authentication', () => {
 
-afterAll(() => {
-  SymBotClient.stopDatafeedEventsService();
-});
-
-test('Retrieve sessionAuthToken', () => {
-  expect(testContext.symAuth.sessionAuthToken).toBeDefined();
-});
-
-test('Retrieve kmAuthToken', () => {
-  expect(testContext.symAuth.kmAuthToken).toBeDefined();
-});
-
-test('Execute getDatafeedEventsService', (done) => {
-
-  const botHearsRequest = ( event, messages ) => {
-    expect(messages[0].stream).toBeDefined();
-    testContext.streamId = messages[0].stream.streamId;
-    done();
-  };
-
-  SymBotClient.getDatafeedEventsService( botHearsRequest );
-});
-
-test('Execute sendMessage', () => {
-  expect.assertions(1);
-  return SymBotClient.sendMessage( testContext.streamId, 'Test sendMessage', null, SymBotClient.MESSAGEML_FORMAT ).then( (data) => {
-    expect(data.messageId).toBeDefined();
+  beforeAll(() => {
+    return SymBotClient.initBot(__dirname + '/../config.json').then(data => {
+      testContext.symAuth = data;
+    })
   });
+
+  afterAll(() => {
+    SymBotClient.stopDatafeedEventsService();
+  });
+
+  test('Retrieve sessionAuthToken', () => {
+    expect(testContext.symAuth.sessionAuthToken).toBeDefined();
+  });
+
+  test('Retrieve kmAuthToken', () => {
+    expect(testContext.symAuth.kmAuthToken).toBeDefined();
+  });
+
+  test('Execute getDatafeedEventsService', (done) => {
+
+    const botHearsRequest = (event, messages) => {
+      expect(messages[0].stream).toBeDefined();
+      testContext.streamId = messages[0].stream.streamId;
+      done();
+    };
+
+    SymBotClient.getDatafeedEventsService(botHearsRequest);
+  });
+
+  test('Execute sendMessage', () => {
+    expect.assertions(1);
+    return SymBotClient.sendMessage(testContext.streamId, 'Test sendMessage', null, SymBotClient.MESSAGEML_FORMAT).then((data) => {
+      expect(data.messageId).toBeDefined();
+    });
+  });
+
 });
+


### PR DESCRIPTION
#48 introduced a bug which ended the request too early when POSTing form-data bodies.

Also:
- More thorough tests for request helper to help avoid regressions
- Add 60 second idle timeout to requests after which the promise will be rejected
- Migrate remaining endpoints to use request helper
- Wrapped the existing tests in `tests/symphony-api-client.test.js` in a `describe` block to make them easier to skip when developing locally since I don't have the right config to make them work
