### PR TITLE
Rewrite DatafeedEventsService

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,27 @@ Symphony API Client for NodeJS
 
 ## Installation
 
-``npm install --save symphony-api-client-node``
+`npm install --save symphony-api-client-node`
 
 ## Usage
 
 ```javascript
-const Symphony = require('symphony-api-client-node');
+const Symphony = require('symphony-api-client-node')
 
-const messageHandler = (eventName, messages) => {
+const onMessage = messages => {
   messages.forEach(message => {
-    console.log('The BOT heard "' + message.messageText +'" from ' + message.initiator.user.displayName);
+    console.log(
+      'The BOT heard "' + message.messageText + '" from ' + message.initiator.user.displayName
+    )
   })
 }
 
-const errorHandler = error => {
+const onError = error => {
   console.error('Error reading data feed', error)
 }
 
 Symphony.initBot(__dirname + '/config.json').then(() => {
-  Symphony.getDatafeedEventsService(messageHandler, errorHandler);
+  Symphony.getDatafeedEventsService({ onMessage, onError })
 })
 ```
 
@@ -30,7 +32,6 @@ Symphony.initBot(__dirname + '/config.json').then(() => {
 The `config.json` file is described on the [Configuration page](https://symphony-developers.symphony.com/docs/configuration-1) of the Symphony Developer Guide.
 
 Create a config.json file in your project.  Below is a sample configuration which includes the properties that can be configured:
-
 
 ```json5
 {
@@ -85,22 +86,34 @@ Create a config.json file in your project.  Below is a sample configuration whic
 
 ## Datafeed resuming
 
-Datafeeds buffer events on the agent up to a small limit. This allows bots to be restarted without missing any events, 
-provided the datafeed ID is persisted and supplied when reconnecting. 
+Datafeeds buffer events on the agent up to a small limit. This allows bots to be restarted without missing any events,
+provided the datafeed ID is persisted and supplied when reconnecting.
 
 ```javascript
-const feedId = /* load feed ID from storage */;
-const feed = Symphony.getDatafeedEventsService(messageHandler, errorHandler, feedId);
-feed.on('created', newFeedId => /* save new feed ID to storage */);
- ```
+const fs = require('fs')
+const localFile = '/path/to/writable/file' // <- change this
+
+const loadId = () => fs.readFileSync(localFile, { encoding: 'utf-8', flag: 'a+' })
+const saveId = id => fs.writeFile(localFile, id, err => err && console.error(err))
+
+const feed = Symphony.getDatafeedEventsService({
+  onMessage,
+  onError,
+  onCreated: saveId,
+  feedId: loadId(),
+})
+```
+
+This simple example assumes that the file system is persisted across restarts which is not always the case
+(e.g. Docker containers). It is recommended to persist the datafeed ID to a database instead if available.
 
 ### Shutting down a bot
 
 There is a known issue that can cause messages to be lost when stopping and resuming a datafeed.
 To avoid this, the datafeed service must hook into Node's exit events and prevent the process
 from exiting until the data feed has closed cleanly (up to 30 seconds). This is done automatically
-if the `NODE_ENV` environment variable is set to 'production' *and* a datafeed 'created' listener 
-has been registered (see above). In other cases the behaviour can be opted into by calling 
+if the `NODE_ENV` environment variable is set to 'production' _and_ a datafeed 'created' listener
+has been registered (see above). In other cases the behaviour can be opted into by calling
 `registerShutdownHooks()` on the feed instance.
 
 See [Express Best Practices](https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ for examples of how to set environment variables.
 
 # Release Notes
 
+## next
+- Enhancement for resuming an existing datafeed. If upgrading to the new `getDatafeedEventsService` method signature, 
+  note that the new `onMessage` handler is passed a single `messages` parameter.
+
 ## 1.0.3
 - Fix to handle support for PKCS12 certificate files
 - Enhancement for Proxy Support. Allow configuring pod, agent and key manager proxies independently.

--- a/lib/SymBotClient/index.js
+++ b/lib/SymBotClient/index.js
@@ -62,17 +62,28 @@ SymBotClient.getConnectionRequestStatus = ConnectionsClient.getConnectionRequest
 /* DatafeedClient Services */
 
 let datafeedInstance
-SymBotClient.getDatafeedEventsService = (messageHandler, errorHandler, feedId) => {
-  datafeedInstance = new DatafeedEventsService()
-  // pass string as first param to handler for back compat
-  datafeedInstance.on('message', messageHandler.bind(null, 'MESSAGE_RECEIVED'))
-  if (errorHandler) {
-    datafeedInstance.on('error', errorHandler)
+SymBotClient.getDatafeedEventsService = options => {
+  // back compat for old function signature
+  if (typeof options === 'function') {
+    // pass string as first param to handler for back compat
+    options = { onMessage: options.bind(null, 'MESSAGE_RECEIVED') }
   }
-  datafeedInstance.start(feedId)
+
+  datafeedInstance = new DatafeedEventsService()
+  for (let event of ['message', 'error', 'created', 'stopped']) {
+    const camelName = `on${event.charAt(0).toUpperCase()}${event.substring(1)}`
+    if (options[camelName]) {
+      datafeedInstance.on(event, options[camelName])
+    }
+  }
+  datafeedInstance.start(options.feedId)
+
   return datafeedInstance
 }
-// todo: remove this method and the datafeedInstance variable in the next major version
+/**
+ * todo: remove this method and the datafeedInstance variable in the next major version
+ * @deprecated Use stop() method on datafeed instance instead
+ */
 SymBotClient.stopDatafeedEventsService = () => {
   console.warn(
     'stopDatafeedEventsService is deprecated. See https://github.com/SymphonyPlatformSolutions/symphony-api-client-node#release-notes'

--- a/tests/DatafeedEventsService/index.test.js
+++ b/tests/DatafeedEventsService/index.test.js
@@ -163,7 +163,6 @@ describe('DatafeedEventsService', () => {
     mockRead(id).reply(200, mockBody)
 
     const messageHandler = jest.fn()
-    process.env
     const feed = initFeed(messageHandler, id)
     stopFeed(feed)
     feed.registerShutdownHooks()

--- a/tests/SymBotClient/index.test.js
+++ b/tests/SymBotClient/index.test.js
@@ -165,21 +165,7 @@ describe('SymBotClient', () => {
   })
 
   describe('#getDatafeedEventsService', () => {
-    it('creates and sets up instance', () => {
-      const feedId = 'abc123'
-      const messageHandler = jest.fn()
-      const errorHandler = jest.fn()
-      const feed = SymBotClient.getDatafeedEventsService(messageHandler, errorHandler, feedId)
-
-      // call bound handler function
-      feed.on.mock.calls[0][1]('hello')
-      expect(messageHandler).toHaveBeenCalledWith('MESSAGE_RECEIVED', 'hello')
-
-      expect(feed.start).toHaveBeenCalledWith(feedId)
-      expect(feed.on).toHaveBeenCalledWith('error', errorHandler)
-    })
-
-    it('allows errorHandler and feedId to be omitted', () => {
+    it('supports old function signature', () => {
       const messageHandler = jest.fn()
       const feed = SymBotClient.getDatafeedEventsService(messageHandler)
 
@@ -188,7 +174,26 @@ describe('SymBotClient', () => {
       expect(messageHandler).toHaveBeenCalledWith('MESSAGE_RECEIVED', 'hello')
 
       expect(feed.start).toHaveBeenCalledWith(undefined)
-      expect(feed.on).not.toHaveBeenCalledWith(expect.any(String), undefined)
+    })
+
+    it('supports new function signature', () => {
+      const feedId = 'abc123'
+      const onMessage = jest.fn()
+      const onError = jest.fn()
+      const feed = SymBotClient.getDatafeedEventsService({onMessage, onError, feedId})
+
+      expect(feed.start).toHaveBeenCalledWith(feedId)
+      expect(feed.on).toHaveBeenCalledWith('message', onMessage)
+      expect(feed.on).toHaveBeenCalledWith('error', onError)
+    })
+
+    it('allows errorHandler and feedId to be omitted', () => {
+      const onMessage = jest.fn()
+      const feed = SymBotClient.getDatafeedEventsService({onMessage})
+
+      expect(feed.start).toHaveBeenCalledWith(undefined)
+      expect(feed.on).toHaveBeenCalledWith('message', onMessage)
+      expect(feed.on).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
Features:
- restarting an existing datafeed
- reporting the ID of a new datafeed
- reporting when the datafeed has errored
- reporting when the datafeed has stopped cleanly
- preventing the node process from exiting until datafeed has stopped cleanly

Should be fully backward compatible provided users are relying only on the functionality exposed by `SymBotClient`.