### PR TITLE
Add a stopping and shutdown event to the DatafeedEventsService

### DIFF
--- a/lib/DatafeedEventsService/index.js
+++ b/lib/DatafeedEventsService/index.js
@@ -8,14 +8,25 @@ const SymMessageParser = require('../SymMessageParser')
  *
  * Usage:
  *   const feed = new Datafeed
- *   feed.on('message', messageHandler) // receives array of parsed messages each time they are received
- *   feed.on('error',   errorHandler)   // receives error when the feed has an unrecoverable error
- *   feed.on('created', saveHandler)    // receives the feed ID each time a new one is created
- *   feed.on('stopped', stopHandler)    // triggered once the datafeed has stopped cleanly
- *   feed.start()                       // create a datafeed and start reading
- *   feed.start(id)                     // or, continue reading existing feed
+ *   feed.on('message', messageHandler)   // receives array of parsed messages each time they are received
+ *   feed.on('error',   errorHandler)     // receives error when the feed has an unrecoverable error
+ *   feed.on('created', saveHandler)      // receives the feed ID each time a new one is created
+ *   feed.on('stopping', stopHandler)     // triggered when the datafeed starts stopping
+ *   feed.on('stopped', stopHandler)      // triggered once the datafeed has stopped cleanly
+ *   feed.on('shutdown', shutdownHandler) // triggered after stopped when the stop was caused by a shutdown hook.
+ *                                        // if no event handler was registered here process.exit will be called.
+ *   feed.start()                         // create a datafeed and start reading
+ *   feed.start(id)                       // or, continue reading existing feed
  *   ...
- *   feed.stop()                        // stop datafeed once current request completes or times out
+ *   feed.stop()                          // stop datafeed once current request completes or times out
+ *
+ * Shutdown hooks:
+ *
+ * This registers shutdown hooks in order to stop the datafeed cleanly and to avoid message loss.
+ * Shutdown hooks are only registered when the NODE_ENV is 'production' and the user has attached a 'created'
+ * event handler that is used to save the datafeed id.
+ * The shutdown hook will call process.exit after the last call from the feed has been completed unless a 'shutdown'
+ * event handler has been registered. In this case it is expected that the caller handle the exit process however they wish to.
  */
 class DatafeedEventsService extends EventEmitter {
   constructor() {
@@ -25,7 +36,10 @@ class DatafeedEventsService extends EventEmitter {
     this.onProcessExit = (event, exitCode = 0) => {
       this.stop(() => {
         console.log('Bot successfully shut down')
-        process.exit(exitCode)
+        this.emit('shutdown', event, exitCode)
+        if (!this.listenerCount('shutdown')) {
+          process.exit(exitCode)
+        }
       })
       console.log('Waiting up to 30 seconds for data feed request to complete')
     }
@@ -126,6 +140,7 @@ class DatafeedEventsService extends EventEmitter {
   stop(onStopped) {
     console.log(`The BOT ${SymBotAuth.botUser.displayName} is shutting down`)
     this.liveStatus = false
+    this.emit('stopping')
     if (onStopped) {
       this.once('stopped', onStopped)
     }

--- a/lib/DatafeedEventsService/index.js
+++ b/lib/DatafeedEventsService/index.js
@@ -32,16 +32,22 @@ class DatafeedEventsService extends EventEmitter {
   constructor() {
     super()
 
+    this.processExitTriggered = false
+
     // process exit handler
     this.onProcessExit = (event, exitCode = 0) => {
-      this.stop(() => {
-        console.log('Bot successfully shut down')
-        this.emit('shutdown', event, exitCode)
-        if (!this.listenerCount('shutdown')) {
-          process.exit(exitCode)
-        }
-      })
-      console.log('Waiting up to 30 seconds for data feed request to complete')
+      if (!this.processExitTriggered) {
+        this.processExitTriggered = true
+        this.stop(() => {
+          console.log('Bot successfully shut down')
+          this.emit('shutdown', event, exitCode)
+          if (!this.listenerCount('shutdown')) {
+            process.exit(exitCode)
+          }
+        })
+        console.log('Waiting up to 30 seconds for data feed request to complete')
+      }
+
     }
 
     // process events to monitor

--- a/tests/DatafeedEventsService/index.test.js
+++ b/tests/DatafeedEventsService/index.test.js
@@ -213,6 +213,20 @@ describe('DatafeedEventsService', () => {
     await mockHasBeenCalled(process.exit)
   })
 
+  it('only triggers shutdown procedure once', async () => {
+    mockRead(id).reply(200, mockBody)
+
+    const messageHandler = jest.fn()
+    const feed = initFeed(messageHandler, id)
+    feed.registerShutdownHooks()
+    console.log.mockImplementation(jest.fn())
+
+    process.emit('SIGINT', {}, 0)
+    process.emit('SIGINT', {}, 0)
+    await mockHasBeenCalled(process.exit)
+    expect(process.exit).toHaveBeenCalledTimes(1)
+  })
+
   it('emits stopping and stopped on SIGINT', async () => {
     mockRead(id).reply(200, mockBody)
 


### PR DESCRIPTION
The shutdown event allows the sdk user to hook into the shutdown process rather than have it force quit when the data feed completes.

The stopping event indicates when it starts to stop. The sdk user can use this event to start to shutdown its own services in preparation for a stop.