### PR TITLE
Adds retry for 503 status code in datafeed and adds workspace settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ jest.config.js
 .idea
 *.iml
 
+# Workspace settings
+.vscode

--- a/lib/DatafeedEventsService/index.js
+++ b/lib/DatafeedEventsService/index.js
@@ -202,7 +202,7 @@ class DatafeedEventsService extends EventEmitter {
   }
 
   _shouldContinueRetry (err) {
-    let isErrNonBlocking = (err.statusCode === 400 || err.statusCode === 'ECONNRESET' || err.statusCode === 'ECONNREFUSED')
+    let isErrNonBlocking = (err.statusCode === 400 ||  err.statusCode === 503 || err.statusCode === 'ECONNRESET' || err.statusCode === 'ECONNREFUSED')
 
     // Exit on 500 (Internal Server Error) only if there are no LBs,
     // otherwise try to reconnect to another agent


### PR DESCRIPTION
This PR amends how the data-feed handles 503 errors so that error messages stop coming through as alerts for this particular status code error.