### PR TITLE
default maxRetries=100

### DIFF
--- a/lib/DatafeedEventsService/index.js
+++ b/lib/DatafeedEventsService/index.js
@@ -30,7 +30,7 @@ const SymElementsParser = require('../SymElementsParser')
  * event handler has been registered. In this case it is expected that the caller handle the exit process however they wish to.
  */
 class DatafeedEventsService extends EventEmitter {
-  constructor () {
+  constructor() {
     super()
 
     this.processExitTriggered = false
@@ -62,10 +62,10 @@ class DatafeedEventsService extends EventEmitter {
     // retry connection constants
     // default 64 seconds as in Google Cloud Storage
     this.MAX_WAIT_INTERVAL = SymConfigLoader.SymConfig.maxWaitInterval ? SymConfigLoader.SymConfig.maxWaitInterval * 1000 : 64000
-    this.MAX_RETRIES = SymConfigLoader.SymConfig.maxRetries || 10
+    this.MAX_RETRIES = SymConfigLoader.SymConfig.maxRetries || 100
   }
 
-  start (feedId = null) {
+  start(feedId = null) {
     for (let event of ['message', 'error']) {
       if (!this.listenerCount(event)) {
         console.warn(`Datafeed has no "${event}" handler`)
@@ -87,7 +87,7 @@ class DatafeedEventsService extends EventEmitter {
     }
   }
 
-  _create () {
+  _create() {
     DatafeedClient.createDatafeed().then(
       ({ id }) => {
         this.id = id
@@ -100,7 +100,7 @@ class DatafeedEventsService extends EventEmitter {
     )
   }
 
-  _read () {
+  _read() {
     DatafeedClient.getEventsFromDatafeed(this.id).then(
       response => {
         if (response.status === 'success') {
@@ -144,7 +144,7 @@ class DatafeedEventsService extends EventEmitter {
     )
   }
 
-  stop (onStopped) {
+  stop(onStopped) {
     console.log(`The BOT ${SymBotAuth.botUser.displayName} is shutting down`)
     this.liveStatus = false
     this.emit('stopping')
@@ -153,19 +153,19 @@ class DatafeedEventsService extends EventEmitter {
     }
   }
 
-  registerShutdownHooks () {
+  registerShutdownHooks() {
     for (let eventName of this.exitEvents) {
       process.on(eventName, this.onProcessExit)
     }
   }
 
-  unregisterShutdownHooks () {
+  unregisterShutdownHooks() {
     for (let eventName of this.exitEvents) {
       process.off(eventName, this.onProcessExit)
     }
   }
 
-  _retryConnection (err) {
+  _retryConnection(err) {
     let waitInterval = this._getExponentialWaitInterval(this.retries, this.MAX_WAIT_INTERVAL)
     let shouldContinueRetry = this._shouldContinueRetry(err)
 
@@ -187,22 +187,19 @@ class DatafeedEventsService extends EventEmitter {
     }
   }
 
-  _getExponentialWaitInterval (retryCount, maxWaitInterval) {
+  _getExponentialWaitInterval(retryCount, maxWaitInterval) {
     let waitInterval = Math.pow(2, retryCount) * 1000 // in milliseconds
     waitInterval = maxWaitInterval ? Math.min(waitInterval, maxWaitInterval) : waitInterval
 
-    if (SymBotAuth.debug) {
-      console.log(
-        '[DEBUG]',
-        'DatafeedEventsService/_retryConnection/waitInterval',
-        waitInterval / 1000 + ' seconds [#' + (this.retries + 1) + ']'
-      )
-    }
+    console.log(
+      'DatafeedEventsService/_retryConnection/waitInterval',
+      waitInterval / 1000 + ' seconds [#' + (this.retries + 1) + ']'
+    )
     return waitInterval
   }
 
-  _shouldContinueRetry (err) {
-    let isErrNonBlocking = (err.statusCode === 400 ||  err.statusCode === 503 || err.statusCode === 'ECONNRESET' || err.statusCode === 'ECONNREFUSED')
+  _shouldContinueRetry(err) {
+    let isErrNonBlocking = (err.statusCode === 400 || err.statusCode === 503 || err.statusCode === 'ECONNRESET' || err.statusCode === 'ECONNREFUSED')
 
     // Exit on 500 (Internal Server Error) only if there are no LBs,
     // otherwise try to reconnect to another agent


### PR DESCRIPTION
We need default retries value = 100 to make SDK trying to reconnect to the agent up to 2 hours, once per minute. Earlier it was 10, that is equivalent to 7-8 minutes only.

Another point is to log statistic info about reconnection trials.