### PR TITLE
APP-3329: Support versions of node >= 12 and fixed use of Buffer constructor

### DIFF
--- a/lib/Jwt/index.js
+++ b/lib/Jwt/index.js
@@ -5,7 +5,7 @@ function nowEpochSeconds () {
 }
 
 function base64urlEncode (str) {
-  return new Buffer(str)
+  return new Buffer.from(str)
     .toString('base64')
     .replace(/\+/g, '-')
     .replace(/\//g, '_')

--- a/lib/SymBotAuth/index.js
+++ b/lib/SymBotAuth/index.js
@@ -330,7 +330,7 @@ SymBotAuth.nowEpochSeconds = () => {
 }
 
 SymBotAuth.base64urlEncode = (str) => {
-  return new Buffer(str)
+  return new Buffer.from(str)
     .toString('base64')
     .replace(/\+/g, '-')
     .replace(/\//g, '_')

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pubsub-js": "^1.7.0"
   },
   "engines": {
-    "node": ">=6.10.3"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Ticket
[APP-3329](https://perzoinc.atlassian.net/browse/APP-3329)

### Description
Updated package.json to have node version >= 12.0.0
Removed use of `Buffer` constructor in favor of `Buffer.from()`.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
