### PR TITLE
#59: Implemented initBot from config objects

### DIFF
--- a/lib/SymBotClient/index.js
+++ b/lib/SymBotClient/index.js
@@ -35,6 +35,20 @@ SymBotClient.initBot = (pathToConfigFile, pathToLoadBalancerConfigFile) => {
   })
 }
 
+SymBotClient.initBotFromObjects = (config, loadBalancerConfig) => {
+  return SymConfigLoader.loadFromObject(config).then(SymConfig => {
+    if (loadBalancerConfig) {
+      return SymLoadBalancerConfigLoader.loadFromObjects(loadBalancerConfig, SymConfig).then(SymLoadBalancerConfig => {
+        SymBotClient.config = SymLoadBalancerConfig
+        return SymBotClient.authenticateBot(SymLoadBalancerConfig)
+      })
+    } else {
+      SymBotClient.config = SymConfig
+      return SymBotClient.authenticateBot(SymConfig)
+    }
+  })
+}
+
 /* Authentication */
 SymBotClient.authenticateBot = (SymConfig) => {
   return SymBotAuth.authenticate(SymConfig).then(symAuth => {

--- a/lib/SymConfigLoader/index.js
+++ b/lib/SymConfigLoader/index.js
@@ -1,27 +1,20 @@
 const fs = require('fs')
+const util = require('util')
 const Q = require('q')
 const HttpsProxyAgent = require('https-proxy-agent')
 const url = require('url')
 
-var SymConfigLoader = {}
+let SymConfigLoader = {}
 
 SymConfigLoader.loadFromFile = (path) => {
-  var defer = Q.defer()
+  // using util.promisify instead of fs/promise because of unit tests mocking fs.readFile
+  return util.promisify(fs.readFile)(path)
+    .then(JSON.parse)
+    .then(SymConfigLoader.loadFromObject);
+}
 
-  fs.readFile(path, function (err, data) {
-    if (err) {
-      defer.reject(err)
-      return
-    }
-
-    let config
-    try {
-      config = JSON.parse(data)
-    } catch (err) {
-      defer.reject(err)
-      return
-    }
-
+SymConfigLoader.loadFromObject = (config) => {
+  return Q.fcall(() => {
     // back compat
     if (config.proxyURL) {
       config.podProxyURL = config.proxyURL
@@ -56,19 +49,17 @@ SymConfigLoader.loadFromFile = (path) => {
     // compatibility with SymLoadBalancerConfigLoader,
     // if LB is used, these functions are overridden
     config.getAgentHost = async () => config.agentHost
-    config.rotateAgent = async () => { }
+    config.rotateAgent = async () => {
+    }
 
     // Do not reject self-signed certificates for API calls
     // ** Do not set this variable for Production Environments **
     if (config.nodeTlsRejectUnauthorized === 0) {
       process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
     }
-
-    SymConfigLoader.SymConfig = config
-    defer.resolve(config)
-  })
-
-  return defer.promise
+    SymConfigLoader.SymConfig = config;
+    return config;
+  });
 }
 
 module.exports = SymConfigLoader

--- a/lib/SymLoadBalancerConfigLoader/index.js
+++ b/lib/SymLoadBalancerConfigLoader/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const util = require('util')
 const Q = require('q')
 
 const request = require('../Request')
@@ -14,31 +15,19 @@ const loadBalancingMethod = {
 }
 
 SymLoadBalancerConfigLoader.loadFromFile = (path, SymConfig) => {
-  let defer = Q.defer()
+  return util.promisify(fs.readFile)(path)
+    .then(JSON.parse)
+    .then((lbConfig) => SymLoadBalancerConfigLoader.loadFromObjects(lbConfig, SymConfig));
+}
 
-  fs.readFile(path, function (err, data) {
-    if (err) {
-      defer.reject(err)
-      return
-    }
-
-    let config
-    try {
-      config = JSON.parse(data)
-    } catch (err) {
-      defer.reject(err)
-      return
-    }
-
-    enhanceSymConfig(config, SymConfig)
+SymLoadBalancerConfigLoader.loadFromObjects = (lbConfig, SymConfig) => {
+  return Q.fcall(() => {
+    enhanceSymConfig(lbConfig, SymConfig)
     SymConfig.getAgentHost = getAgentHost
     SymConfig.rotateAgent = rotateAgent
     SymConfig.getActualAgentHost = getActualAgentHost
-
-    defer.resolve(SymConfig)
-  })
-
-  return defer.promise
+    return SymConfig
+  });
 }
 
 function enhanceSymConfig (configFromFile, SymConfig) {

--- a/tests/SymConfigLoader/index.test.js
+++ b/tests/SymConfigLoader/index.test.js
@@ -24,6 +24,14 @@ describe('SymConfigLoader', () => {
         });
       });
 
+      it('creates a proxy from object', () => {
+        return SymConfigLoader.loadFromObject({
+          proxyURL: 'https://agent-proxy-url/',
+        }).then(config => {
+          expect(config.agentProxy.proxy.href).toEqual('https://agent-proxy-url/');
+        });
+      });
+
       it('creates an authenticated proxy', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
@@ -35,6 +43,18 @@ describe('SymConfigLoader', () => {
 
         return SymConfigLoader.loadFromFile('a-path').then(config => {
           expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.agentProxy.proxy.href).toEqual(
+            'https://test-user:test-pass@agent-proxy-url/'
+          );
+        });
+      });
+
+      it('creates an authenticated proxy from object', () => {
+        return SymConfigLoader.loadFromObject({
+          proxyURL: 'https://agent-proxy-url/',
+          proxyUsername: 'test-user',
+          proxyPassword: 'test-pass',
+        }).then(config => {
           expect(config.agentProxy.proxy.href).toEqual(
             'https://test-user:test-pass@agent-proxy-url/'
           );
@@ -57,7 +77,20 @@ describe('SymConfigLoader', () => {
           );
         });
       });
+
+      it('encodes special characters from object', () => {
+        return SymConfigLoader.loadFromObject({
+          proxyURL: 'https://agent-proxy-url/',
+          proxyUsername: 'test-user-$%',
+          proxyPassword: 'test-pass-$%',
+        }).then(config => {
+          expect(config.agentProxy.proxy.href).toEqual(
+            'https://test-user-%24%25:test-pass-%24%25@agent-proxy-url/'
+          );
+        });
+      });
     });
+
 
     describe('pod proxy', () => {
       it('creates a proxy', () => {
@@ -73,6 +106,14 @@ describe('SymConfigLoader', () => {
         });
       });
 
+      it('creates a proxy from object', () => {
+        return SymConfigLoader.loadFromObject({
+          proxyURL: 'https://pod-proxy-url/',
+        }).then(config => {
+          expect(config.podProxy.proxy.href).toEqual('https://pod-proxy-url/');
+        });
+      });
+
       it('creates an authenticated proxy', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
@@ -84,6 +125,18 @@ describe('SymConfigLoader', () => {
 
         return SymConfigLoader.loadFromFile('a-path').then(config => {
           expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.podProxy.proxy.href).toEqual(
+            'https://test-user:test-pass@pod-proxy-url/'
+          );
+        });
+      });
+
+      it('creates an authenticated proxy from object', () => {
+        return SymConfigLoader.loadFromObject({
+          proxyURL: 'https://pod-proxy-url/',
+          proxyUsername: 'test-user',
+          proxyPassword: 'test-pass',
+        }).then(config => {
           expect(config.podProxy.proxy.href).toEqual(
             'https://test-user:test-pass@pod-proxy-url/'
           );
@@ -107,6 +160,18 @@ describe('SymConfigLoader', () => {
         });
       });
 
+      it('encodes special characters from object', () => {
+        return SymConfigLoader.loadFromObject({
+          proxyURL: 'https://pod-proxy-url/',
+          proxyUsername: 'test-user-$%',
+          proxyPassword: 'test-pass-$%',
+        }).then(config => {
+          expect(config.podProxy.proxy.href).toEqual(
+            'https://test-user-%24%25:test-pass-%24%25@pod-proxy-url/'
+          );
+        });
+      });
+
       it('creates a proxy for only the pod', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
@@ -116,6 +181,15 @@ describe('SymConfigLoader', () => {
 
         return SymConfigLoader.loadFromFile('a-path').then(config => {
           expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.podProxy.proxy.href).toEqual('https://pod-proxy-url/');
+          expect(config.agentProxy).toBeUndefined();
+        });
+      });
+
+      it('creates a proxy for only the pod from object', () => {
+        return SymConfigLoader.loadFromObject({
+          podProxyURL: 'https://pod-proxy-url/',
+        }).then(config => {
           expect(config.podProxy.proxy.href).toEqual('https://pod-proxy-url/');
           expect(config.agentProxy).toBeUndefined();
         });
@@ -132,6 +206,14 @@ describe('SymConfigLoader', () => {
 
         return SymConfigLoader.loadFromFile('a-path').then(config => {
           expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.keyManagerProxy.proxy.href).toEqual('https://km-proxy-url/');
+        });
+      });
+
+      it('creates a proxy from object', () => {
+        return SymConfigLoader.loadFromObject({
+          keyManagerProxyURL: 'https://km-proxy-url/',
+        }).then(config => {
           expect(config.keyManagerProxy.proxy.href).toEqual('https://km-proxy-url/');
         });
       });
@@ -153,6 +235,18 @@ describe('SymConfigLoader', () => {
         });
       });
 
+      it('creates an authenticated proxy from object', () => {
+        return SymConfigLoader.loadFromObject({
+          keyManagerProxyURL: 'https://km-proxy-url/',
+          keyManagerProxyUsername: 'test-user',
+          keyManagerProxyPassword: 'test-pass',
+        }).then(config => {
+          expect(config.keyManagerProxy.proxy.href).toEqual(
+            'https://test-user:test-pass@km-proxy-url/'
+          );
+        });
+      });
+
       it('encodes special characters', () => {
         mockFs.readFile = jest.fn((path, cb) => {
           return cb(null, JSON.stringify({
@@ -164,6 +258,18 @@ describe('SymConfigLoader', () => {
 
         return SymConfigLoader.loadFromFile('a-path').then(config => {
           expect(mockFs.readFile).toHaveBeenCalledWith('a-path', expect.any(Function));
+          expect(config.keyManagerProxy.proxy.href).toEqual(
+            'https://test-user-%24%25:test-pass-%24%25@km-proxy-url/'
+          );
+        });
+      });
+
+      it('encodes special characters from object', () => {
+        return SymConfigLoader.loadFromObject({
+          keyManagerProxyURL: 'https://km-proxy-url/',
+          keyManagerProxyUsername: 'test-user-$%',
+          keyManagerProxyPassword: 'test-pass-$%',
+        }).then(config => {
           expect(config.keyManagerProxy.proxy.href).toEqual(
             'https://test-user-%24%25:test-pass-%24%25@km-proxy-url/'
           );

--- a/tests/SymLoadBalancerConfigLoader/index.test.js
+++ b/tests/SymLoadBalancerConfigLoader/index.test.js
@@ -57,4 +57,14 @@ describe('SymLoadBalancerConfigLoader', () => {
       expect(SymBotClient.config.agentServers.length).toEqual(lbMockConfig.agentServers.length);
     });
   });
+
+  it('configures lb from objects', () => {
+    return SymBotClient.initBotFromObjects(mainMockConfig, lbMockConfig).then(symAuth => {
+      expect(SymBotClient.config.podHost).toEqual(mainMockConfig.podHost);
+
+      expect(SymBotClient.config.loadBalancing.method).toEqual(lbMockConfig.loadBalancing.method);
+      expect(SymBotClient.config.loadBalancing.method).toEqual(lbMockConfig.loadBalancing.method);
+      expect(SymBotClient.config.agentServers.length).toEqual(lbMockConfig.agentServers.length);
+    });
+  });
 });


### PR DESCRIPTION
### Ticket
#59 

### Description
Bot can be initialized from objects directly thanks to `initBotFromObjects`.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [ ] Public functions properly commented
