### PR TITLE
Automatic publishing with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,29 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@4.1.0
+  node: circleci/node@4.5.1
 
+jobs:
+  release:
+    executor:
+      name: node/default
+      tag: '14.15.4'
+    steps:
+      - checkout
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > ~/repo/.npmrc
+      - run: npm publish
 workflows:
   node-tests:
     jobs:
       - node/test:
           version: 14.15.4
+      - release:
+          requires:
+            - node/test
+          filters:
+            tags:
+              only: /[0-9]+\.[0-9]+\.[0-9]+/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Trigger publication on NPM once a tag is create on GH (i.e a release)