### PR TITLE
Fix tag filtering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ workflows:
     jobs:
       - node/test:
           version: 14.15.4
+          filters:
+            tags:
+              only: /[0-9]+\.[0-9]+\.[0-9]+/
       - release:
           requires:
             - node/test


### PR DESCRIPTION
Because the job is required, it needs to be enabled for tags as well.
